### PR TITLE
Add option to load plugin from different route, enhance route picking

### DIFF
--- a/frontend/config/dev.webpack.config.js
+++ b/frontend/config/dev.webpack.config.js
@@ -24,6 +24,7 @@ const webpackProxy = {
   }),
   routes: {
     '/api/plugins/console-demo-plugin': { host: 'http://localhost:9000' },
+    '/apps/sources': { host: 'http://localhost:8003' },
     ...(process.env.API_PORT && {
       '/api/hac': { host: `http://localhost:${process.env.API_PORT}` },
     }),

--- a/frontend/config/dev.webpack.config.js
+++ b/frontend/config/dev.webpack.config.js
@@ -24,7 +24,6 @@ const webpackProxy = {
   }),
   routes: {
     '/api/plugins/console-demo-plugin': { host: 'http://localhost:9000' },
-    '/apps/sources': { host: 'http://localhost:8003' },
     ...(process.env.API_PORT && {
       '/api/hac': { host: `http://localhost:${process.env.API_PORT}` },
     }),

--- a/frontend/src/AppEntry.tsx
+++ b/frontend/src/AppEntry.tsx
@@ -10,7 +10,7 @@ import { IncludePlugins } from '@console/mount/src/components/plugins';
 import { activePlugins } from './Utils/constants';
 
 window.SERVER_FLAGS = {
-  consolePlugins: activePlugins,
+  consolePlugins: activePlugins.map(({ name }) => name),
 };
 
 const AppEntry = () => (

--- a/frontend/src/Navigation.ts
+++ b/frontend/src/Navigation.ts
@@ -36,7 +36,10 @@ const getAllExtensions: GetAllExtensions = async () => {
             const url = `${pathPrefix}/${pluginName}/plugin-manifest.json`;
             const response: Response = await fetch(url);
             if (response.status !== 200) {
-                throw new Error(`${url} - ${response.status} - ${response.statusText}`);
+                const msg = `${url} - ${response.status} - ${response.statusText}`;
+                // eslint-disable-next-line no-console
+                console.error(msg);
+                throw new Error(msg);
             }
             const manifest: ConsolePluginManifestJSON = await response.json();
             return manifest.extensions;

--- a/frontend/src/Navigation.ts
+++ b/frontend/src/Navigation.ts
@@ -1,5 +1,6 @@
 import { activePlugins } from './Utils/constants';
 import { HrefNavItem, NavSection } from '@console/dynamic-plugin-sdk/src';
+import { EnabledPlugin } from '@console/mount/src/components/plugins/IncludePlugins';
 
 export interface RouteProps {
   isHidden?: boolean;
@@ -19,8 +20,8 @@ export type CalculateRoutes = (navIdentifier: [string, string], currentNamespace
 const getAllExtensions: GetAllExtensions = async () => {
   return (
     await Promise.all(
-      activePlugins.flatMap(async (pluginName: string) => {
-        const { extensions } = (await (await fetch(`/api/plugins/${pluginName}/plugin-manifest.json`))?.json()) || {};
+      activePlugins.flatMap(async ({ name: pluginName, pathPrefix = '/api/plugins' }: EnabledPlugin) => {
+        const { extensions } = (await (await fetch(`${pathPrefix}/${pluginName}/plugin-manifest.json`))?.json()) || {};
         return extensions;
       }),
     )

--- a/frontend/src/Navigation.ts
+++ b/frontend/src/Navigation.ts
@@ -1,6 +1,8 @@
 import { activePlugins } from './Utils/constants';
 import { HrefNavItem, NavSection } from '@console/dynamic-plugin-sdk/src';
 import { EnabledPlugin } from '@console/mount/src/components/plugins/IncludePlugins';
+import { Extension } from '@console/dynamic-plugin-sdk/src/types';
+import { ConsolePluginManifestJSON } from '@console/dynamic-plugin-sdk/src/schema/plugin-manifest';
 
 export interface RouteProps {
   isHidden?: boolean;
@@ -14,26 +16,38 @@ export interface DynamicNav {
   currentNamespace: string;
 }
 
-export type GetAllExtensions = () => Promise<(HrefNavItem | NavSection)[]>;
+const navExtensionTypes = ['console.navigation/href', 'console.navigation/section'];
+type NavExtension = HrefNavItem | NavSection;
+
+export type GetAllExtensions = () => Promise<NavExtension[]>;
 export type CalculateRoutes = (navIdentifier: [string, string], currentNamespace: string, extensions: (HrefNavItem | NavSection)[]) => RouteProps[];
 
-const getAllExtensions: GetAllExtensions = async () => {
-  const extensions = (await Promise.allSettled(
-    activePlugins.flatMap(async ({ name: pluginName, pathPrefix = '/api/plugins' }: EnabledPlugin) => {
-      try {
-        const manifest = await (await fetch(`${pathPrefix}/${pluginName}/plugin-manifest.json`))?.json();
-        return manifest?.extensions;
-      } catch (e) {
-        console.log(e);
-      }
-    }),
-  ));
+const isFulfilledPromise = (result: PromiseSettledResult<Extension[]>): result is PromiseFulfilledResult<Extension[]> => {
+    return result.status === 'fulfilled' && Boolean(result.value);
+};
 
-  return extensions
-  .filter((result): result is PromiseFulfilledResult<(HrefNavItem | NavSection)[]> => result.status === 'fulfilled' && result.value)
+const isNavItem = (extension: Extension): extension is NavExtension => {
+    return navExtensionTypes.includes(extension.type);
+};
+
+const getAllExtensions: GetAllExtensions = async () => {
+    const results: PromiseSettledResult<Extension[]>[] = await Promise.allSettled(
+        activePlugins.flatMap(async ({ name: pluginName, pathPrefix = '/api/plugins' }: EnabledPlugin) => {
+            const url = `${pathPrefix}/${pluginName}/plugin-manifest.json`;
+            const response: Response = await fetch(url);
+            if (response.status !== 200) {
+                throw new Error(`${url} - ${response.status} - ${response.statusText}`);
+            }
+            const manifest: ConsolePluginManifestJSON = await response.json();
+            return manifest.extensions;
+        }),
+    );
+
+  return results
+  .filter(isFulfilledPromise)
   .map(({ value }) => value)
   .flat()
-  .filter(({ type }) => ['console.navigation/href', 'console.navigation/section'].includes(type));
+  .filter(isNavItem);
 };
 
 const calculateRoutes: CalculateRoutes = ([appId, navSection], currentNamespace, extensions) => {
@@ -48,13 +62,15 @@ const calculateRoutes: CalculateRoutes = ([appId, navSection], currentNamespace,
 
 export default async ({ dynamicNav, currentNamespace }: DynamicNav) => {
   const [appId, navSection] = dynamicNav.split('/');
-  let allExtensions = [];
+  let allExtensions: NavExtension[] = [];
   let routes: RouteProps | RouteProps[];
   try {
     allExtensions = await getAllExtensions();
     routes = calculateRoutes([appId, navSection], currentNamespace, allExtensions);
-  } catch {
+  } catch (e) {
     routes = [{ isHidden: true }];
+    // eslint-disable-next-line no-console
+    console.error('Problem fetching extensions', e);
   }
   const { properties: currSection } =
     allExtensions.find(({ type, properties }: NavSection) => type === 'console.navigation/section' && properties.id === navSection) || {};

--- a/frontend/src/Utils/constants.ts
+++ b/frontend/src/Utils/constants.ts
@@ -1,1 +1,1 @@
-export const activePlugins = ['console-demo-plugin'];
+export const activePlugins = [{ name: 'console-demo-plugin' }, { name: 'sources', pathPrefix: '/apps' }];

--- a/frontend/src/poc-code/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/src/poc-code/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -27,7 +27,7 @@ const commonManifestFields: Partial<readPkg.PackageJson> = {
 };
 
 const commonFiles: GeneratedPackage['filesToCopy'] = {
-  '../../../LICENSE': 'LICENSE',
+  '../../../../LICENSE': 'LICENSE',
   'README.md': 'README.md',
 };
 

--- a/frontend/src/poc-code/console-mount/src/components/plugins/IncludePlugins.tsx
+++ b/frontend/src/poc-code/console-mount/src/components/plugins/IncludePlugins.tsx
@@ -6,9 +6,15 @@ import { useReduxStore } from '../../redux';
 import { getEnabledDynamicPluginNames } from './utils';
 import { loadDynamicPlugin } from '@console/dynamic-plugin-sdk/src/runtime/plugin-loader';
 
+export type EnabledPlugin = {
+  name: string;
+  pathPrefix?: string;
+}
+
 type PluginProps = {
-  enabledPlugins?: string[];
+  enabledPlugins?: EnabledPlugin[];
   onPluginRegister?: Function;
+  pathPrefix?: String;
 };
 
 const IncludePlugins = ({ enabledPlugins, onPluginRegister = noop }: PluginProps) => {
@@ -18,9 +24,9 @@ const IncludePlugins = ({ enabledPlugins, onPluginRegister = noop }: PluginProps
   React.useEffect(() => {
     if (pluginStore) {
       enabledPlugins &&
-        enabledPlugins.forEach(async (item) => {
-          const manifest = await (await fetch(`/api/plugins/${item}/plugin-manifest.json`)).json();
-          loadDynamicPlugin(`/api/plugins/${item}/`, manifest).then((pluginName) => {
+        enabledPlugins.forEach(async ({ name: item, pathPrefix = '/api/plugins' }) => {
+          const manifest = await (await fetch(`${pathPrefix}/${item}/plugin-manifest.json`)).json();
+          loadDynamicPlugin(`${pathPrefix}/${item}/`, manifest).then((pluginName) => {
             pluginStore.setDynamicPluginEnabled(pluginName, true);
           });
         });


### PR DESCRIPTION
### Load plugin from different route

Since we want to support additional apps to enhance our UI we should add a way how to determine from which source each plugin actually comes. This PR adds such support by including `pathPrefix` to each enabled plugins, this way we can pull plugins from console.redhat.com applications as well. This will require the app to expose such plugins via Webpack plugin (work already done in https://github.com/RedHatInsights/frontend-components/pull/1316)

### Enhance route picking

Since we don't want to fully rely only on first and second part of URL we can utilize [react-router#matchPath](https://v5.reactrouter.com/web/api/matchPath) to calculate if route fits our needs. With slight addition of section to prepend the path from plugin to determine if plugin comes from section (feature enhancements should fully look at section route is supposed to mount into).