### PR TITLE
Use proper pathname in checkPath

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.1",
-    "@redhat-cloud-services/frontend-components-config": "^4.3.5",
+    "@redhat-cloud-services/frontend-components-config": "^4.5.4",
     "@scalprum/core": "^0.0.12",
     "@types/classnames": "^2.3.1",
     "@types/jest": "21.x",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,11 +7,13 @@ import { getRegistry } from '@redhat-cloud-services/frontend-components-utilitie
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useStore } from 'react-redux';
 
 const App: React.FC = () => {
   const history = useHistory();
 
   const chrome = useChrome();
+  const store = useStore();
 
   React.useEffect(() => {
     const registry = getRegistry();
@@ -30,7 +32,7 @@ const App: React.FC = () => {
 
   return (
     <React.Fragment>
-      <NotificationsPortal />
+      <NotificationsPortal store={store} />
       <Routes />
     </React.Fragment>
   );

--- a/frontend/src/Routes/DynamicRoute/DynamicRoute.tsx
+++ b/frontend/src/Routes/DynamicRoute/DynamicRoute.tsx
@@ -23,7 +23,7 @@ type RoutePage = {
 
 const checkPath = (pathname, { path, exact }: RoutePage) => {
   const [, section] = pathname.split('/');
-  return matchPath(location.pathname, { path, exact }) || matchPath(location.pathname, { path: `/${section}${path}`, exact });
+  return matchPath(pathname, { path, exact }) || matchPath(pathname, { path: `/${section}${path}`, exact });
 };
 const DynamicRoute: React.FC<DynamicRouteProps> = ({ location }) => {
   const [Component, setComponent] = React.useState<React.ExoticComponent<any>>(React.Fragment);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -652,7 +652,7 @@
   resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.6.tgz#5e1ee2d78c8ce451cf5da543024ccfa594d96e54"
   integrity sha512-8EoRKJAmAKYTkmTF0LflKDfN1synRNFs5EH5HMqxVfOODM07Y5NcJ/mSGZrwSvx1xkVaUgGpF8JfC6UIbwSnag==
 
-"@redhat-cloud-services/frontend-components-config@^4.3.5":
+"@redhat-cloud-services/frontend-components-config@^4.5.4":
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.5.4.tgz#2bcf59e70c0fe269115ed50b042b55e89cb98fc9"
   integrity sha512-p3TGckoLs/V050Tq0R9SnUf0NuA9e0w3Tj6HWbzxEERUhDkBS9DR7SdOnHDUFUT+0n8i72wiZQ56NNNoD/2jpA==


### PR DESCRIPTION
### CheckPath returning correct route

When calling `checkPath` it uses `location.pathname` which is incorrect. Let's use the `pathname` from react-router.