### PR TITLE
Enable build, test and release github workflow

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,0 +1,58 @@
+name: Build and test
+on: push
+jobs:
+  install-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - name: Install Yarn
+        run: npm install -g yarn
+      - name: Setup Nodejs with yarn caching
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          cache: yarn
+      - run: pushd frontend
+      - name: Install dependencies
+        run: yarn
+      - run: popd
+  test-files:
+    needs: [install-dependencies]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          cache: 'yarn'
+      - run: pushd frontend
+      - name: Run lint
+        run: yarn lint
+      - name: Run tests
+        run: yarn test
+      - run: popd
+    
+  build-files:
+    needs: [install-dependencies]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          cache: 'yarn'
+      - run: pushd frontend
+      - name: Run build
+        run: yarn build
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ${{ github.workspace }}/frontend/dist/*
+          key: ${{ github.sha }}
+      - run: popd

--- a/.github/build.yml
+++ b/.github/build.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - run: popd
+
   test-files:
     needs: [install-dependencies]
     runs-on: ubuntu-latest

--- a/.github/build.yml
+++ b/.github/build.yml
@@ -18,7 +18,7 @@ jobs:
           cache: yarn
       - run: pushd frontend
       - name: Install dependencies
-        run: yarn
+        run: yarn install
       - run: popd
   test-files:
     needs: [install-dependencies]

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,160 @@
+name: Release workflow
+on:
+  workflow_run:
+    workflows: ['Build and test']
+    branches: [main, master, ci-beta, qa-beta, stage-beta, prod-stable, ci-stable, qa-stable, stage-stable, prod-stable]
+    types:
+      - completed
+jobs:
+  pull-scripts:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: mkdir ${{ github.workspace }}/scripts
+      - name: Pull release file
+        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/release.sh > ${{ github.workspace }}/scripts/release.sh
+      - run: chmod +x "${GITHUB_WORKSPACE}/scripts/release.sh"
+      - name: Pull nginx conf file
+        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/nginx_conf_gen.sh > ./scripts/nginx_conf_gen.sh
+      - run: chmod +x "${GITHUB_WORKSPACE}/scripts/nginx_conf_gen.sh"
+      - name: Pull quay push file
+        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/quay_push.sh > ./scripts/quay_push.sh
+      - run: chmod +x "${GITHUB_WORKSPACE}/scripts/quay_push.sh"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/scripts/*
+          key: ${{ github.sha }}-scripts
+  pull-jenkins:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: mkdir ${{ github.workspace }}/.travis
+      - name: Pull the file
+        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/Jenkinsfile > ${{ github.workspace }}/.travis/58231b16fdee45a03a4ee3cf94a9f2c3
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.travis/58231b16fdee45a03a4ee3cf94a9f2c3
+          key: ${{ github.sha }}-travis
+  set-ssh:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add SSH key
+        run: |
+            mkdir -p /home/runner/.ssh
+            ssh-keyscan github.com >> /home/runner/.ssh/known_hosts
+            echo "${{ secrets.SSH_PRIVATE_KEY }}" > /home/runner/.ssh/github_actions
+            chmod 600 /home/runner/.ssh/github_actions
+            echo "Host github.com
+              HostName github.com
+              User git
+              AddKeysToAgent yes
+              IdentityFile /home/runner/.ssh/github_actions" >> /home/runner/.ssh/config
+      - uses: actions/cache@v2
+        with:
+          path: /home/runner/.ssh/*
+          key: ${{ github.sha }}-ssh
+  Release-to-build:
+    needs: [pull-scripts, pull-jenkins, set-ssh]
+    runs-on: ubuntu-latest
+    env:
+      COMMIT_AUTHOR_USERNAME: GitHub actions
+      COMMIT_AUTHOR_EMAIL: actions@github.com
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set env variables
+        run: |
+          echo "TRAVIS_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          echo "TRAVIS_BUILD_NUMBER=$GITHUB_RUN_ID" >> $GITHUB_ENV
+          echo "APP_BUILD_DIR=${{ github.workspace }}/frontend/dist"
+          echo "TRAVIS_COMMIT_MESSAGE=`git log -1 --pretty=format:"%s"`" >> $GITHUB_ENV
+          echo "REPO=`node -e 'console.log(require("./package.json").insights.buildrepo)'`" >> $GITHUB_ENV
+      - run: git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
+      - uses: actions/cache@v2
+        with:
+          path: /home/runner/.ssh/*
+          key: ${{ github.sha }}-ssh
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/scripts/*
+          key: ${{ github.sha }}-scripts
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.travis/58231b16fdee45a03a4ee3cf94a9f2c3
+          key: ${{ github.sha }}-travis
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ${{ github.workspace }}/dist/*
+          key: ${{ github.sha }}
+      - name: Run the deploy
+        run: ${{ github.workspace }}/custom_release.sh
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/dist/*
+          key: ${{ github.sha }}-released
+  Run-generate-image:
+    needs: pull-scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          echo "TRAVIS_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          echo "APP_ROOT=${{ github.workspace }}/dist" >> $GITHUB_ENV
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/scripts/*
+          key: ${{ github.sha }}-scripts
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ${{ github.workspace }}/dist/*
+          key: ${{ github.sha }}
+      - name: Generate configs
+        run: ${{ github.workspace }}/scripts/nginx_conf_gen.sh
+      - name: Check the build repo
+        run: ls -lah ${{ github.workspace }}/dist
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/dist/*
+          key: ${{ github.sha }}-docker-conf
+  Run-build-and-publish:
+    needs: [Run-generate-image, Release-to-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/dist/*
+          key: ${{ github.sha }}-docker-conf
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/dist/*
+          key: ${{ github.sha }}-released
+      - name: List dist folder
+        run: ls -lah ${{ github.workspace }}/dist
+      - name: Set env variables
+        run: |
+          echo "SRC_HASH=`git rev-parse --verify HEAD`" >> $GITHUB_ENV
+          echo "GIT_BRANCH=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+      - name: Deploy to quay
+        run: |
+          APP_NAME=`node -e 'console.log(require("./package.json").imagename || require("./package.json").insights.appname)'`
+          cd ${{ github.workspace }}/dist
+          docker build . -t ${APP_NAME}
+
+          docker tag ${APP_NAME} quay.io/redhat-cloud-services/${APP_NAME}
+
+          docker tag ${APP_NAME} quay.io/redhat-cloud-services/${APP_NAME}:${SRC_HASH}
+
+          docker tag ${APP_NAME} quay.io/redhat-cloud-services/${APP_NAME}:${GIT_BRANCH}
+
+          echo ${{ secrets.DOCKER_TOKEN }} | docker login quay.io --username \$oauthtoken --password-stdin
+
+          docker push quay.io/redhat-cloud-services/${APP_NAME}
+          docker push quay.io/redhat-cloud-services/${APP_NAME}:${SRC_HASH}
+          docker push quay.io/redhat-cloud-services/${APP_NAME}:${GIT_BRANCH}
+      
+

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -11,31 +11,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: mkdir ${{ github.workspace }}/scripts
+      - run: mkdir ${{ github.workspace }}/frontend/scripts
       - name: Pull release file
-        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/release.sh > ${{ github.workspace }}/scripts/release.sh
-      - run: chmod +x "${GITHUB_WORKSPACE}/scripts/release.sh"
+        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/release.sh > ${{ github.workspace }}/frontend/scripts/release.sh
+      - run: chmod +x "${{ github.workspace }}/frontend/scripts/release.sh"
       - name: Pull nginx conf file
-        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/nginx_conf_gen.sh > ./scripts/nginx_conf_gen.sh
-      - run: chmod +x "${GITHUB_WORKSPACE}/scripts/nginx_conf_gen.sh"
+        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/nginx_conf_gen.sh > ${{ github.workspace }}/frontend/scripts/nginx_conf_gen.sh
+      - run: chmod +x "${{ github.workspace }}/frontend/scripts/nginx_conf_gen.sh"
       - name: Pull quay push file
-        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/quay_push.sh > ./scripts/quay_push.sh
-      - run: chmod +x "${GITHUB_WORKSPACE}/scripts/quay_push.sh"
+        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/quay_push.sh > ${{ github.workspace }}/frontend/scripts/quay_push.sh
+      - run: chmod +x "${{ github.workspace }}/frontend/scripts/quay_push.sh"
       - uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/scripts/*
+          path: ${{ github.workspace }}/frontend/scripts/*
           key: ${{ github.sha }}-scripts
   pull-jenkins:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: mkdir ${{ github.workspace }}/.travis
+      - run: mkdir ${{ github.workspace }}/frontend/.travis
       - name: Pull the file
-        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/Jenkinsfile > ${{ github.workspace }}/.travis/58231b16fdee45a03a4ee3cf94a9f2c3
+        run: curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/Jenkinsfile > ${{ github.workspace }}/frontend/.travis/58231b16fdee45a03a4ee3cf94a9f2c3
       - uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/.travis/58231b16fdee45a03a4ee3cf94a9f2c3
+          path: ${{ github.workspace }}/frontend/.travis/58231b16fdee45a03a4ee3cf94a9f2c3
           key: ${{ github.sha }}-travis
   set-ssh:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -70,7 +70,7 @@ jobs:
           echo "TRAVIS_BUILD_NUMBER=$GITHUB_RUN_ID" >> $GITHUB_ENV
           echo "APP_BUILD_DIR=${{ github.workspace }}/frontend/dist"
           echo "TRAVIS_COMMIT_MESSAGE=`git log -1 --pretty=format:"%s"`" >> $GITHUB_ENV
-          echo "REPO=`node -e 'console.log(require("./package.json").insights.buildrepo)'`" >> $GITHUB_ENV
+          echo "REPO=`node -e 'console.log(require("${{ github.workspace }}/frontend/package.json").insights.buildrepo)'`" >> $GITHUB_ENV
       - run: git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
       - uses: actions/cache@v2
         with:
@@ -78,22 +78,22 @@ jobs:
           key: ${{ github.sha }}-ssh
       - uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/scripts/*
+          path: ${{ github.workspace }}/frontend/scripts/*
           key: ${{ github.sha }}-scripts
       - uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/.travis/58231b16fdee45a03a4ee3cf94a9f2c3
+          path: ${{ github.workspace }}/frontend/.travis/58231b16fdee45a03a4ee3cf94a9f2c3
           key: ${{ github.sha }}-travis
       - uses: actions/cache@v2
         id: restore-build
         with:
-          path: ${{ github.workspace }}/dist/*
+          path: ${{ github.workspace }}/frontend/dist/*
           key: ${{ github.sha }}
       - name: Run the deploy
         run: ${{ github.workspace }}/custom_release.sh
       - uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/dist/*
+          path: ${{ github.workspace }}/frontend/dist/*
           key: ${{ github.sha }}-released
   Run-generate-image:
     needs: pull-scripts
@@ -102,23 +102,23 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           echo "TRAVIS_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
-          echo "APP_ROOT=${{ github.workspace }}/dist" >> $GITHUB_ENV
+          echo "APP_ROOT=${{ github.workspace }}/frontend/dist" >> $GITHUB_ENV
       - uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/scripts/*
+          path: ${{ github.workspace }}/frontend/scripts/*
           key: ${{ github.sha }}-scripts
       - uses: actions/cache@v2
         id: restore-build
         with:
-          path: ${{ github.workspace }}/dist/*
+          path: ${{ github.workspace }}/frontend/dist/*
           key: ${{ github.sha }}
       - name: Generate configs
-        run: ${{ github.workspace }}/scripts/nginx_conf_gen.sh
+        run: ${{ github.workspace }}/frontend/scripts/nginx_conf_gen.sh
       - name: Check the build repo
-        run: ls -lah ${{ github.workspace }}/dist
+        run: ls -lah ${{ github.workspace }}/frontend/dist
       - uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/dist/*
+          path: ${{ github.workspace }}/frontend/dist/*
           key: ${{ github.sha }}-docker-conf
   Run-build-and-publish:
     needs: [Run-generate-image, Release-to-build]
@@ -127,22 +127,20 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/dist/*
+          path: ${{ github.workspace }}/frontend/dist/*
           key: ${{ github.sha }}-docker-conf
       - uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/dist/*
+          path: ${{ github.workspace }}/frontend/dist/*
           key: ${{ github.sha }}-released
-      - name: List dist folder
-        run: ls -lah ${{ github.workspace }}/dist
       - name: Set env variables
         run: |
           echo "SRC_HASH=`git rev-parse --verify HEAD`" >> $GITHUB_ENV
           echo "GIT_BRANCH=${GITHUB_REF_NAME}" >> $GITHUB_ENV
       - name: Deploy to quay
         run: |
-          APP_NAME=`node -e 'console.log(require("./package.json").imagename || require("./package.json").insights.appname)'`
-          cd ${{ github.workspace }}/dist
+          APP_NAME=`node -e 'console.log(require("${{ github.workspace }}/frontend/package.json").imagename || require("./package.json").insights.appname)'`
+          cd ${{ github.workspace }}/frontend/dist
           docker build . -t ${APP_NAME}
 
           docker tag ${APP_NAME} quay.io/redhat-cloud-services/${APP_NAME}

--- a/custom_release.sh
+++ b/custom_release.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+if [[ "${TRAVIS_BRANCH}" = "master" || "${TRAVIS_BRANCH}" = "main" ]]
+then
+    for env in ci qa stage
+    do
+        echo "PUSHING ${env}-beta"
+        rm -rf ./dist/.git
+        ./scripts/release.sh "${env}-beta"
+    done
+fi
+
+if [ "${TRAVIS_BRANCH}" = "stable" ]
+then
+    for env in ci qa stage
+    do
+        echo "PUSHING ${env}-stable"
+        rm -rf ./dist/.git
+        ./scripts/release.sh "${env}-stable"
+    done
+fi
+
+if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+    echo "PUSHING ${TRAVIS_BRANCH}"
+    rm -rf ./build/.git
+    ./scripts/release.sh "${TRAVIS_BRANCH}"
+fi

--- a/custom_release.sh
+++ b/custom_release.sh
@@ -2,6 +2,8 @@
 set -e
 set -x
 
+pushd frontend
+
 if [[ "${TRAVIS_BRANCH}" = "master" || "${TRAVIS_BRANCH}" = "main" ]]
 then
     for env in ci qa stage
@@ -27,3 +29,5 @@ if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]];
     rm -rf ./build/.git
     ./scripts/release.sh "${TRAVIS_BRANCH}"
 fi
+
+popd

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,6 +89,7 @@
     "webpack-bundle-analyzer": "4.4.2"
   },
   "insights": {
-    "appname": "hac-core"
+    "appname": "hac-core",
+    "buildrepo": "git@github.com:RedHatInsights/hac-core-frontend-build.git"
   }
 }


### PR DESCRIPTION
### Github actions

* Build workflow
  * Install - installs yarn and dependencies
  * Test - run both lint and test scripts
  * Build - run the build and store it in cache for later use
* Release workflow
  * pull-scripts - this job pulls scripts from [RedHatInsights/insights-frontend-builder-common](https://github.com/RedHatInsights/insights-frontend-builder-common)
  * pull-jenkins - pull Jenkins file from builder common to properly deploy app to Akamai
  * set-ssh - this workflow uses SSH key to push to [RedHatInsights/hac-core-frontend-build](https://github.com/RedHatInsights/hac-core-frontend-build)
  * Release-to-build - runs several scripts to push the build folder
  * Run-generate-image - generates Dockerfile and nginx
  * Run-build-and-publish - builds and publishes the build folder into quay