### PR TITLE
Add base to be include when fetching plugin manifest and entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to run with dynamic plugin from openshift console, simply host the d
 
 ### Running with dynamic plugins - new dynamic plugin
 
-If you want to run the hac-core with dynamic plugin served outside openshift no need for any extra steps. Just run your dynamic plugin and hac-core.
+If you want to run the hac-core with dynamic plugin served outside openshift no need for any extra steps. Just run your dynamic plugin using `npm run start:federated` and hac-core with `yarn dev`. This will start dynamic plugin in federation mode and hac-core will be the host application. The path over which your plugin is available will be printed when starting it, you should then go to `/config/dev.webpack.config.js` and adjust it based on the comments there. After adjusting it, you should restart the `hac-core` app.
 
 ## Development
 

--- a/frontend/config/dev.webpack.config.js
+++ b/frontend/config/dev.webpack.config.js
@@ -23,10 +23,6 @@ const webpackProxy = {
     localChrome: process.env.INSIGHTS_CHROME,
   }),
   routes: {
-    // In order to serve your plugin locally change this line
-    '/api/plugins/console-demo-plugin': { host: 'http://localhost:9000' },
-    // '/beta/api/plugins/console-demo-plugin': { host: 'http://localhost:8003' },
-    // first part is the plugin URL, host is your localhost URL with port
     ...(process.env.API_PORT && {
       '/api/hac': { host: `http://localhost:${process.env.API_PORT}` },
     }),
@@ -36,6 +32,20 @@ const webpackProxy = {
       },
     }),
   },
+  customProxy: [
+    {
+      // if you want to host different plugin than `console-demo-plugin` locally adjust this line
+      context: ['/beta/api/plugins/console-demo-plugin', '/api/plugins/console-demo-plugin'],
+      // In order to serve your plugin locally on your server change this line ↓
+      target: 'http://localhost:9000',
+      secure: false,
+      changeOrigin: true,
+      pathRewrite: {
+        // if you don't want to rewrite `/beta/api/plugins` to `/api/plugins` remove this line
+        '^/beta/api/plugins/console-demo-plugin': '/api/plugins/console-demo-plugin',
+      },
+    },
+  ],
 };
 
 const { config: webpackConfig, plugins } = config({

--- a/frontend/src/AppEntry.tsx
+++ b/frontend/src/AppEntry.tsx
@@ -8,18 +8,22 @@ import logger from 'redux-logger';
 import { IncludePlugins } from '@console/mount/src/components/plugins';
 // import MainAppContent from '@console/mount/src/components/foundation/MainAppContent';
 import { activePlugins } from './Utils/constants';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 window.SERVER_FLAGS = {
   consolePlugins: activePlugins.map(({ name }) => name),
 };
 
-const AppEntry = () => (
-  <Provider store={init(process.env.NODE_ENV !== 'production' && logger).getStore()}>
-    <Router basename={getBaseName(window.location.pathname, 1)}>
-      <IncludePlugins enabledPlugins={activePlugins} />
-      <App />
-    </Router>
-  </Provider>
-);
+const AppEntry = () => {
+  const { isBeta } = useChrome();
+  return (
+    <Provider store={init(process.env.NODE_ENV !== 'production' && logger).getStore()}>
+      <Router basename={getBaseName(window.location.pathname, 1)}>
+        <IncludePlugins enabledPlugins={activePlugins} base={isBeta?.() ? '/beta' : ''} />
+        <App />
+      </Router>
+    </Provider>
+  );
+};
 
 export default AppEntry;

--- a/frontend/src/Navigation.ts
+++ b/frontend/src/Navigation.ts
@@ -39,7 +39,8 @@ const isNavItem = (extension: Extension): extension is NavExtension => {
 const getAllExtensions: GetAllExtensions = async () => {
   const results: PromiseSettledResult<Extension[]>[] = await Promise.allSettled(
     activePlugins.flatMap(async ({ name: pluginName, pathPrefix = '/api/plugins' }: EnabledPlugin) => {
-      const url = `${pathPrefix}/${pluginName}/plugin-manifest.json`;
+      // TODO: once we are hook use chrome to calculate root
+      const url = `./${pathPrefix}/${pluginName}/plugin-manifest.json`;
       const response: Response = await fetch(url);
       if (response.status !== 200) {
         const msg = `${url} - ${response.status} - ${response.statusText}`;

--- a/frontend/src/Navigation.ts
+++ b/frontend/src/Navigation.ts
@@ -4,6 +4,7 @@ import { HrefNavItem, NavSection } from '@console/dynamic-plugin-sdk/src';
 import { EnabledPlugin } from '@console/mount/src/components/plugins/IncludePlugins';
 import { Extension } from '@console/dynamic-plugin-sdk/src/types';
 import { ConsolePluginManifestJSON } from '@console/dynamic-plugin-sdk/src/schema/plugin-manifest';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 export interface RouteProps {
   isHidden?: boolean;
@@ -15,12 +16,13 @@ export interface RouteProps {
 export interface DynamicNav {
   dynamicNav: string;
   currentNamespace: string;
+  base?: string;
 }
 
 const navExtensionTypes = ['console.navigation/href', 'console.navigation/section'];
 type NavExtension = HrefNavItem | NavSection;
 
-export type GetAllExtensions = () => Promise<NavExtension[]>;
+export type GetAllExtensions = (base?: string) => Promise<NavExtension[]>;
 export type CalculateRoutes = (navIdentifier: [string, string], currentNamespace: string, extensions: (HrefNavItem | NavSection)[]) => RouteProps[];
 export type Navigation = {
   expandable: boolean;
@@ -36,11 +38,10 @@ const isNavItem = (extension: Extension): extension is NavExtension => {
   return navExtensionTypes.includes(extension.type);
 };
 
-const getAllExtensions: GetAllExtensions = async () => {
+const getAllExtensions: GetAllExtensions = async (base = '') => {
   const results: PromiseSettledResult<Extension[]>[] = await Promise.allSettled(
     activePlugins.flatMap(async ({ name: pluginName, pathPrefix = '/api/plugins' }: EnabledPlugin) => {
-      // TODO: once we are hook use chrome to calculate root
-      const url = `./${pathPrefix}/${pluginName}/plugin-manifest.json`;
+      const url = `${base}${pathPrefix}/${pluginName}/plugin-manifest.json`;
       const response: Response = await fetch(url);
       if (response.status !== 200) {
         const msg = `${url} - ${response.status} - ${response.statusText}`;
@@ -70,12 +71,12 @@ const calculateRoutes: CalculateRoutes = ([appId, navSection], currentNamespace,
     }));
 };
 
-const calculateNavigation = async ({ dynamicNav, currentNamespace }: DynamicNav): Promise<Navigation | RouteProps[]> => {
+const calculateNavigation = async ({ dynamicNav, currentNamespace, base }: DynamicNav): Promise<Navigation | RouteProps[]> => {
   const [appId, navSection] = dynamicNav.split('/');
   let allExtensions: NavExtension[] = [];
   let routes: RouteProps | RouteProps[];
   try {
-    allExtensions = await getAllExtensions();
+    allExtensions = await getAllExtensions(base);
     routes = calculateRoutes([appId, navSection], currentNamespace, allExtensions);
     if (routes.length === 0) {
       routes = [{ isHidden: true }];
@@ -99,10 +100,11 @@ const calculateNavigation = async ({ dynamicNav, currentNamespace }: DynamicNav)
 export const useNavigation = ({ dynamicNav, currentNamespace }: DynamicNav): Navigation | RouteProps[] => {
   const [navigation, setNavigation] = React.useState<Navigation | RouteProps[]>();
   const unmounted = React.useRef<boolean>(false);
+  const { isBeta } = useChrome();
   React.useEffect(() => {
     if (dynamicNav) {
       // this is just one off for now, but we can start building on this
-      calculateNavigation({ dynamicNav, currentNamespace }).then((data: Navigation | RouteProps[]) => {
+      calculateNavigation({ dynamicNav, currentNamespace, base: isBeta() ? `/beta` : '' }).then((data: Navigation | RouteProps[]) => {
         if (!unmounted.current) {
           setNavigation(data);
         }

--- a/frontend/src/poc-code/console-mount/src/components/plugins/IncludePlugins.tsx
+++ b/frontend/src/poc-code/console-mount/src/components/plugins/IncludePlugins.tsx
@@ -14,10 +14,10 @@ export type EnabledPlugin = {
 type PluginProps = {
   enabledPlugins?: EnabledPlugin[];
   onPluginRegister?: Function;
-  pathPrefix?: String;
+  base?: String;
 };
 
-const IncludePlugins = ({ enabledPlugins, onPluginRegister = noop }: PluginProps) => {
+const IncludePlugins = ({ enabledPlugins, onPluginRegister = noop, base }: PluginProps) => {
   const [pluginStore, setPluginStore] = React.useState<PluginStore>();
   const store = useReduxStore();
 
@@ -25,8 +25,8 @@ const IncludePlugins = ({ enabledPlugins, onPluginRegister = noop }: PluginProps
     if (pluginStore) {
       enabledPlugins &&
         enabledPlugins.forEach(async ({ name: item, pathPrefix = '/api/plugins' }) => {
-          const manifest = await (await fetch(`${pathPrefix}/${item}/plugin-manifest.json`)).json();
-          loadDynamicPlugin(`${pathPrefix}/${item}/`, manifest).then((pluginName) => {
+          const manifest = await (await fetch(`${base}${pathPrefix}/${item}/plugin-manifest.json`)).json();
+          loadDynamicPlugin(`${base}${pathPrefix}/${item}/`, manifest).then((pluginName) => {
             pluginStore.setDynamicPluginEnabled(pluginName, true);
           });
         });


### PR DESCRIPTION
### UI trying to fetch plugins from non-beta env

When on any beta environment the UI is trying to fetch dynamic plugin from root route. This is not correct as we have to support beta environment first. This PR changes such thing by prepending fetching manifests and plugin entries with calculated base from chrome API.