### PR TITLE
Add release scripts for both build repo and image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,7 @@ yarn-error.log*
 
 .DS_Store
 coverage
+
+# Used when releasing to build repository and quay image
 frontend/scripts
 frontend/.travis

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ yarn-error.log*
 
 .DS_Store
 coverage
+frontend/scripts
+frontend/.travis

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,6 +89,7 @@
     "webpack-bundle-analyzer": "4.4.2"
   },
   "insights": {
-    "appname": "hac-core"
+    "appname": "hac-core",
+    "buildrepo": "git@github.com:RedHatInsights/hac-core-frontend-build.git"
   }
 }

--- a/release-build-repo.sh
+++ b/release-build-repo.sh
@@ -1,0 +1,46 @@
+
+#!/usr/bin/env bash
+set -e
+set -x
+
+pushd frontend
+export COMMIT_AUTHOR_USERNAME="Openshift CI"
+export COMMIT_AUTHOR_EMAIL="openshift@redhat.com"
+export TRAVIS_BRANCH=`git rev-parse --abbrev-ref HEAD`
+export TRAVIS_BUILD_NUMBER=""
+export TRAVIS_COMMIT_MESSAGE=`git log -1 --pretty=format:"%s"`
+export REPO=`node -e 'console.log(require("./package.json").insights.buildrepo)'`
+
+mkdir -p ./scripts
+mkdir -p ./.travis
+curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/release.sh > ./scripts/release.sh
+curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/Jenkinsfile > ./.travis/58231b16fdee45a03a4ee3cf94a9f2c3
+chmod +x -R ./scripts/
+
+if [[ "${TRAVIS_BRANCH}" = "master" || "${TRAVIS_BRANCH}" = "main" ]]
+then
+    for env in ci qa stage
+    do
+        echo "PUSHING ${env}-beta"
+        rm -rf ./dist/.git
+        ./scripts/release.sh "${env}-beta"
+    done
+fi
+
+if [ "${TRAVIS_BRANCH}" = "stable" ]
+then
+    for env in ci qa stage
+    do
+        echo "PUSHING ${env}-stable"
+        rm -rf ./dist/.git
+        ./scripts/release.sh "${env}-stable"
+    done
+fi
+
+if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+    echo "PUSHING ${TRAVIS_BRANCH}"
+    rm -rf ./build/.git
+    ./scripts/release.sh "${TRAVIS_BRANCH}"
+fi
+
+popd

--- a/release-build-repo.sh
+++ b/release-build-repo.sh
@@ -4,6 +4,8 @@ set -e
 set -x
 
 pushd frontend
+
+# Prepare env variables needed in future by release script
 export COMMIT_AUTHOR_USERNAME="Openshift CI"
 export COMMIT_AUTHOR_EMAIL="openshift@redhat.com"
 export TRAVIS_BRANCH=`git rev-parse --abbrev-ref HEAD`
@@ -11,12 +13,16 @@ export TRAVIS_BUILD_NUMBER=""
 export TRAVIS_COMMIT_MESSAGE=`git log -1 --pretty=format:"%s"`
 export REPO=`node -e 'console.log(require("./package.json").insights.buildrepo)'`
 
+# Scipts folder holds scripts from frontend-common-builder
 mkdir -p ./scripts
+
+# .travis folder is used by release script to promote code to jenkins
 mkdir -p ./.travis
 curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/release.sh > ./scripts/release.sh
 curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/Jenkinsfile > ./.travis/58231b16fdee45a03a4ee3cf94a9f2c3
 chmod +x -R ./scripts/
 
+# When pushed to master/main let's release to [ci, qa, stage]-beta
 if [[ "${TRAVIS_BRANCH}" = "master" || "${TRAVIS_BRANCH}" = "main" ]]
 then
     for env in ci qa stage
@@ -27,6 +33,7 @@ then
     done
 fi
 
+# When pushed to stable let's release to [ci, qa, stage]-stable
 if [ "${TRAVIS_BRANCH}" = "stable" ]
 then
     for env in ci qa stage
@@ -37,6 +44,7 @@ then
     done
 fi
 
+# When pushed to prod-beta or prod-stable let's release to prod-beta or prod-stable
 if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
     echo "PUSHING ${TRAVIS_BRANCH}"
     rm -rf ./build/.git

--- a/release-image.sh
+++ b/release-image.sh
@@ -3,17 +3,21 @@ set -e
 set -x
 
 pushd frontend
+
+# Prepare env variables needed in future by release script
 export TRAVIS_BRANCH=`git rev-parse --abbrev-ref HEAD`
 export APP_ROOT=$PWD/dist
 export SRC_HASH=`git rev-parse --verify HEAD`
 export GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 export APP_NAME=`node -e 'console.log(require("./package.json").imagename || require("./package.json").insights.appname)'`
 
+# Scipts folder holds scripts from frontend-common-builder
 mkdir -p ./scripts
 curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/nginx_conf_gen.sh > ./scripts/nginx_conf_gen.sh
 curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/quay_push.sh > ./scripts/quay_push.sh
 chmod +x -R ./scripts/
 
+# This script will generate nginx and Dockerfile, unless they are already created
 ./scripts/nginx_conf_gen.sh
 cd $APP_ROOT
 docker build . -t ${APP_NAME}

--- a/release-image.sh
+++ b/release-image.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+pushd frontend
+export TRAVIS_BRANCH=`git rev-parse --abbrev-ref HEAD`
+export APP_ROOT=$PWD/dist
+export SRC_HASH=`git rev-parse --verify HEAD`
+export GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+export APP_NAME=`node -e 'console.log(require("./package.json").imagename || require("./package.json").insights.appname)'`
+
+mkdir -p ./scripts
+curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/nginx_conf_gen.sh > ./scripts/nginx_conf_gen.sh
+curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/quay_push.sh > ./scripts/quay_push.sh
+chmod +x -R ./scripts/
+
+./scripts/nginx_conf_gen.sh
+cd $APP_ROOT
+docker build . -t ${APP_NAME}
+
+docker tag ${APP_NAME} quay.io/redhat-cloud-services/${APP_NAME}
+
+docker tag ${APP_NAME} quay.io/redhat-cloud-services/${APP_NAME}:${SRC_HASH}
+
+docker tag ${APP_NAME} quay.io/redhat-cloud-services/${APP_NAME}:${GIT_BRANCH}
+
+echo $DOCKER_TOKEN | docker login quay.io --username \$oauthtoken --password-stdin
+
+docker push quay.io/redhat-cloud-services/${APP_NAME}
+docker push quay.io/redhat-cloud-services/${APP_NAME}:${SRC_HASH}
+docker push quay.io/redhat-cloud-services/${APP_NAME}:${GIT_BRANCH}
+popd


### PR DESCRIPTION
In order to use new Prow tasks defined in https://github.com/openshift/release/pull/24323 we have to add 2 new scripts

### Add release script to build repo

This fully utilize [RedHatInsights/insights-frontend-builder-common/src/release.sh](https://github.com/RedHatInsights/insights-frontend-builder-common/blob/master/src/release.sh), which requires a few variables to be set.

### Add release script to quay

This utilizes [RedHatInsights/insights-frontend-builder-common/src/nginx_conf_gen.sh](https://github.com/RedHatInsights/insights-frontend-builder-common/blob/master/src/nginx_conf_gen.sh) to generate both nginx config and Docker file. It then uses quay custom commands to push image to it.