### PR TITLE
Add /testK8s route & component

### DIFF
--- a/frontend/config/dev.webpack.config.js
+++ b/frontend/config/dev.webpack.config.js
@@ -2,6 +2,7 @@ const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const commonPlugins = require('./plugins');
 const mergeTsConfigAliases = require('./mergeTsConfigAliases');
+const { K8sTargetURL } = require('../constants');
 
 const insightsProxy = {
   https: false,
@@ -50,7 +51,7 @@ const webpackProxy = {
   customProxy: [
     {
       context: (path) => path.includes('/api/k8s'),
-      target: 'https://api-toolchain-host-operator.apps.appstudio-stage.x99m.p1.openshiftapps.com:443',
+      target: K8sTargetURL,
       secure: false,
       changeOrigin: true,
       autoRewrite: true,

--- a/frontend/config/dev.webpack.config.js
+++ b/frontend/config/dev.webpack.config.js
@@ -49,6 +49,15 @@ const webpackProxy = {
   },
   customProxy: [
     {
+      context: (path) => path.includes('/api/k8s'),
+      target: 'https://api-toolchain-host-operator.apps.appstudio-stage.x99m.p1.openshiftapps.com:443',
+      secure: false,
+      changeOrigin: true,
+      autoRewrite: true,
+      ws: true,
+      pathRewrite: { '^/api/k8s': '' },
+    },
+    {
       // if you want to host different plugin than `console-demo-plugin` locally adjust this line
       context: ['/beta/api/plugins/console-demo-plugin', '/api/plugins/console-demo-plugin'],
       // In order to serve your plugin locally on your server change this line ↓

--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -1,0 +1,4 @@
+/**
+ * Current AppStudio DevSandbox K8s URL.
+ */
+module.exports.K8sTargetURL = 'https://api-toolchain-host-operator.apps.appstudio-stage.x99m.p1.openshiftapps.com:443';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "nightly": "yarn deploy",
     "dev": "yarn start:proxy:beta",
     "start": "webpack serve --config config/dev.webpack.config.js",
+    "start:k8s": "REMOTE_CONFIG=ci ENVIRONMENT=prod BETA=true PROXY=true yarn start",
     "start:proxy": "yarn build-sdk && PROXY=true BETA=true webpack serve --config config/dev.webpack.config.js",
     "start:proxy:beta": "yarn build-sdk && PROXY=true BETA=true webpack serve --config config/dev.webpack.config.js",
     "start:beta": "BETA=true npm start",

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -3,6 +3,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import EmptyRoute from '@console/mount/src/components/foundation/static-routes/EmptyRoute';
+import TestK8s from './poc-code/testK8s/TestK8s';
 
 const DynamicRoute = React.lazy(() => import(/* webpackChunkName: "DynamicRoute" */ './Routes/DynamicRoute/DynamicRoute'));
 
@@ -15,6 +16,7 @@ export const Routes: React.FC = () => (
     }
   >
     <Switch>
+      <Route exact path="/testK8s" component={TestK8s} />
       <Route path="/:dynamicPath" component={DynamicRoute} />
       <Route exact path="/" component={EmptyRoute} />
       <Route>

--- a/frontend/src/poc-code/testK8s/README.md
+++ b/frontend/src/poc-code/testK8s/README.md
@@ -1,0 +1,5 @@
+# Test K8s
+
+This is a set of files to test K8s functionality in ConsoleDot. This is not long-lived, do not copy anything within'.
+
+`./shared/..` files are copied from HAC-Dev to mirror the changes they did to `./dynamic-plugin-sdk.ts`

--- a/frontend/src/poc-code/testK8s/TestK8s.tsx
+++ b/frontend/src/poc-code/testK8s/TestK8s.tsx
@@ -1,0 +1,208 @@
+/* eslint-disable no-console */
+import * as React from 'react';
+import { Button, PageSection, TextInput } from '@patternfly/react-core';
+import {
+  k8sCreateResource,
+  k8sDeleteResource,
+  k8sGetResource,
+  k8sListResource,
+  K8sModel,
+  k8sPatchResource,
+  K8sResourceCommon,
+  k8sUpdateResource,
+  // useK8sWatchResource,
+} from './dynamic-plugin-sdk';
+
+const ProjectModel: K8sModel = {
+  apiVersion: 'v1',
+  apiGroup: 'project.openshift.io',
+  kind: 'Project',
+  abbr: 'PR',
+  label: 'Project',
+  labelPlural: 'Projects',
+  plural: 'projects',
+};
+const ConfigMapModel: K8sModel = {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  abbr: 'CM',
+  plural: 'configmaps',
+  labelPlural: 'ConfigMaps',
+  label: 'ConfigMap',
+  namespaced: true,
+};
+
+enum ActionType {
+  LIST = 'list',
+  CREATE = 'create',
+  GET = 'get',
+  PATCH = 'patch',
+  PUT = 'put',
+  DELETE = 'delete',
+}
+
+const TestK8s: React.FC = () => {
+  const [r, setR] = React.useState(null);
+  const [namespace, setNamespace] = React.useState<string>('default');
+  const [name, setName] = React.useState<string>('test');
+  const [status, setStatus] = React.useState<string>('');
+  const [action, setAction] = React.useState<ActionType | null>(null);
+
+  // const result = useK8sWatchResource({
+  //   groupVersionKind: { version: 'v1', kind: 'ConfigMap' },
+  //   name: 'test',
+  //   namespace,
+  // });
+  // const result = useK8sWatchResource(
+  //   namespace === 'default' // default namespace has 100s of configmaps, don't fetch it
+  //     ? {}
+  //     : {
+  //         // groupVersionKind: { group: 'project.openshift.io', version: 'v1', kind: 'Project' },
+  //         groupVersionKind: { version: 'v1', kind: 'ConfigMap' },
+  //         isList: true,
+  //         namespace,
+  //       },
+  // );
+  // const hookResource = result[0];
+  // console.debug('render result', result);
+
+  React.useEffect(() => {
+    const testConfigMapMetadata = {
+      metadata: {
+        name,
+        namespace,
+      },
+    };
+    const testConfigMapData: K8sResourceCommon & { [key: string]: any } = {
+      apiVersion: ConfigMapModel.apiVersion,
+      kind: ConfigMapModel.kind,
+      ...testConfigMapMetadata,
+      data: {
+        test: 'true',
+      },
+    };
+
+    let promise = null;
+    switch (action) {
+      case ActionType.LIST:
+        // TODO: this can work sorta for getting your namespace value
+        // response[0].metadata.name === your namespace
+        promise = k8sListResource({
+          model: ProjectModel,
+        }).then((data) => {
+          // Lock in the namespace
+          let ns = null;
+          if (Array.isArray(data)) {
+            const namespaces = data.map((dataResource) => dataResource.metadata.name);
+            console.debug('++++available namespaces:', namespaces);
+            ns = namespaces[0];
+          } else if (data?.metadata?.namespace) {
+            ns = data.metadata.namespace;
+          }
+
+          if (ns) {
+            setAction(null); // prevent re-invoking this effect/call
+            setNamespace(ns);
+          } else {
+            // eslint-disable-next-line no-alert
+            alert('Could not find namespace; you are likely not able to do much as we are targeting "default"');
+          }
+          return data;
+        });
+        break;
+      case ActionType.CREATE:
+        promise = k8sCreateResource({
+          model: ConfigMapModel,
+          data: testConfigMapData,
+        });
+        break;
+      case ActionType.GET:
+        promise = k8sGetResource({
+          model: ConfigMapModel,
+          name: testConfigMapMetadata.metadata.name,
+          ns: testConfigMapMetadata.metadata.namespace,
+        });
+        break;
+      case ActionType.PATCH:
+        promise = k8sPatchResource({
+          model: ConfigMapModel,
+          resource: testConfigMapMetadata,
+          data: [
+            {
+              op: 'replace',
+              path: '/data/test',
+              value: 'false',
+            },
+          ],
+        });
+        break;
+      case ActionType.PUT:
+        promise = k8sUpdateResource({
+          model: ConfigMapModel,
+          name: testConfigMapMetadata.metadata.name,
+          ns: testConfigMapMetadata.metadata.namespace,
+          data: { ...testConfigMapData, data: { ...testConfigMapData.data, new: 'prop' } },
+        });
+        break;
+      case ActionType.DELETE:
+        promise = k8sDeleteResource({
+          model: ConfigMapModel,
+          resource: testConfigMapMetadata,
+        });
+        break;
+      case null:
+        // ignore effect
+        break;
+      default:
+        // this shouldn't happen, catch state for missed cases
+        throw new Error('uh oh!');
+    }
+    promise
+      ?.then((data) => {
+        setStatus(`${action} response:`);
+        setR(data);
+        console.debug(`++++${action}!`, data);
+      })
+      .catch((err) => {
+        console.error(`++++failed ${action}`, err);
+        setStatus('failed call');
+        setR(null);
+      })
+      .finally(() => {
+        setAction(null); // prevent the hook for re-firing on name change
+      });
+  }, [action, name, namespace]);
+
+  return (
+    <PageSection>
+      <TextInput placeholder="ConfigMap name" onChange={(v) => setName(v)} value={name} />
+      <div>
+        <p>Test calls -- predefined data; use the above input to make/update/get multiple ConfigMaps</p>
+        {Object.values(ActionType).map((v) => (
+          <React.Fragment key={v}>
+            <Button isDisabled={v !== ActionType.LIST && namespace === 'default'} onClick={() => setAction(v)}>
+              {v}
+            </Button>{' '}
+          </React.Fragment>
+        ))}
+        In `{namespace}` namespace
+      </div>
+      {/*{hookResource ? (*/}
+      {/*  <>*/}
+      {/*    {Array.isArray(hookResource) && <p>{hookResource.length} item(s) in the array</p>}*/}
+      {/*    <pre>{JSON.stringify(hookResource, null, 2)}</pre>*/}
+      {/*  </>*/}
+      {/*) : (*/}
+      {/*  'No watched resource'*/}
+      {/*)}*/}
+      {r && (
+        <>
+          <div>{status}</div>
+          <pre>{JSON.stringify(r, null, 2)}</pre>
+        </>
+      )}
+    </PageSection>
+  );
+};
+
+export default TestK8s;

--- a/frontend/src/poc-code/testK8s/TestK8s.tsx
+++ b/frontend/src/poc-code/testK8s/TestK8s.tsx
@@ -32,6 +32,7 @@ const ConfigMapModel: K8sModel = {
   namespaced: true,
 };
 
+// eslint-disable-next-line no-shadow
 enum ActionType {
   LIST = 'list',
   CREATE = 'create',

--- a/frontend/src/poc-code/testK8s/dynamic-plugin-sdk.ts
+++ b/frontend/src/poc-code/testK8s/dynamic-plugin-sdk.ts
@@ -1,0 +1,648 @@
+/* eslint-disable */
+import * as React from 'react';
+import * as _ from 'lodash';
+import { HttpError } from './shared/utils/error/http-error';
+
+const HOOK_POLL_DELAY = 2000; // change this if you want the useHook to go faster / slower on polls
+
+/* throw away fetch methods */
+const k8sBasePath = `/api/k8s`; // webpack proxy path
+
+export const validateStatus = async (
+  response: Response
+) => {
+  if (response.ok) {
+    return response;
+  }
+
+  if (response.status === 401) {
+    throw new HttpError('Invalid token. Are you working with Prod SSO token?', response.status, response);
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (!contentType || contentType.indexOf('json') === -1) {
+    throw new HttpError(response.statusText, response.status, response);
+  }
+
+  if (response.status === 403) {
+    return response.json().then((json) => {
+      throw new HttpError(
+        json.message || 'Access denied due to cluster policy.',
+        response.status,
+        response,
+        json,
+      );
+    });
+  }
+
+  return response.json().then((json) => {
+    const cause = json.details?.causes?.[0];
+    let reason;
+    if (cause) {
+      reason = `Error "${cause.message}" for field "${cause.field}".`;
+    }
+    if (!reason) {
+      reason = json.message;
+    }
+    if (!reason) {
+      reason = json.error;
+    }
+    if (!reason) {
+      reason = response.statusText;
+    }
+
+    throw new HttpError(reason, response.status, response, json);
+  });
+};
+
+const commonFetch = async (url, method, options, timeout): Promise<any> => {
+  // Grab the token out of the cookie for ConsoleDot | if not proxying to prod, token will be invalid even if it is there
+  const cookieToken = document.cookie.split('; ').find((val) => val.startsWith('cs_jwt='));
+  if (!cookieToken) {
+    return Promise.reject('Could not make k8s call. Unable to find token.');
+  }
+  const [,token] = cookieToken.split('=');
+
+  const allOptions = _.defaultsDeep({ method }, options, { headers: { Accept: 'application/json' } });
+  allOptions.headers.Authorization = `Bearer ${token}`;
+  try {
+    const response = await fetch(url, allOptions).then(validateStatus);
+    const json = await response.json();
+    return Promise.resolve(json);
+  } catch(e) {
+    return Promise.reject(e);
+  }
+};
+
+const consoleFetchSendJSON = (
+  url: string,
+  method: string,
+  json = null,
+  options: RequestInit = {},
+  timeout: number,
+) => {
+  const allOptions: Record<string, any> = {
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': `application/${
+        method === 'PATCH' ? 'json-patch+json' : 'json'
+      };charset=UTF-8`,
+    },
+  };
+  if (json) {
+    allOptions.body = JSON.stringify(json);
+  }
+  return commonFetch(url, method, _.defaultsDeep(allOptions, options), timeout);
+};
+
+export const coFetchJSON = (...args) => commonFetch.apply(undefined, args);
+coFetchJSON.post = (url, json) => consoleFetchSendJSON(url, 'POST', json, undefined, undefined);
+coFetchJSON.put = (url, json) => consoleFetchSendJSON(url, 'PUT', json, undefined, undefined);
+coFetchJSON.patch = (url, json) => consoleFetchSendJSON(url, 'PATCH', json, undefined, undefined);
+coFetchJSON.delete = (url, json, options) => consoleFetchSendJSON(url, 'DELETE', json, options, undefined);
+
+/* ---------------- *
+ *  Internal Types  *
+ * ---------------- */
+type Patch = {
+  op: string;
+  path: string;
+  value?: any;
+};
+type QueryParams = {
+  watch?: string;
+  labelSelector?: string;
+  fieldSelector?: string;
+  resourceVersion?: string;
+  [key: string]: string;
+};
+type Options = {
+  ns?: string;
+  name?: string;
+  path?: string;
+  queryParams?: QueryParams;
+};
+enum Operator {
+  Exists = 'Exists',
+  DoesNotExist = 'DoesNotExist',
+  In = 'In',
+  NotIn = 'NotIn',
+  Equals = 'Equals',
+  NotEqual = 'NotEqual',
+  GreaterThan = 'GreaterThan',
+  LessThan = 'LessThan',
+  NotEquals = 'NotEquals',
+}
+type MatchExpression = {
+  key: string;
+  operator: Operator | string;
+  values?: string[];
+  value?: string;
+};
+type MatchLabels = {
+  [key: string]: string;
+};
+type Selector = {
+  matchLabels?: MatchLabels;
+  matchExpressions?: MatchExpression[];
+};
+type OwnerReference = {
+  name: string;
+  kind: string;
+  uid: string;
+  apiVersion: string;
+  controller?: boolean;
+  blockOwnerDeletion?: boolean;
+};
+type ObjectMetadata = {
+  annotations?: { [key: string]: string };
+  clusterName?: string;
+  creationTimestamp?: string;
+  deletionGracePeriodSeconds?: number;
+  deletionTimestamp?: string;
+  finalizers?: string[];
+  generateName?: string;
+  generation?: number;
+  labels?: { [key: string]: string };
+  managedFields?: any[];
+  name?: string;
+  namespace?: string;
+  ownerReferences?: OwnerReference[];
+  resourceVersion?: string;
+  uid?: string;
+};
+
+
+/* ---------------- *
+ *  External Types  *
+ * ---------------- */
+export type K8sResourceCommon = {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: ObjectMetadata;
+};
+export type K8sModel = {
+  abbr: string;
+  kind: string;
+  label: string;
+  labelKey?: string;
+  labelPlural: string;
+  labelPluralKey?: string;
+  plural: string;
+  propagationPolicy?: 'Foreground' | 'Background';
+
+  id?: string;
+  crd?: boolean;
+  apiVersion: string;
+  apiGroup?: string;
+  namespaced?: boolean;
+  selector?: Selector;
+  labels?: { [key: string]: string };
+  annotations?: { [key: string]: string };
+  // verbs?: K8sVerb[];
+  shortNames?: string[];
+  // badge?: BadgeType;
+  color?: string;
+
+  // Legacy option for supporing plural names in URL paths when `crd: true`.
+  // This should not be set for new models, but is needed to avoid breaking
+  // existing links as we transition to using the API group in URL paths.
+  legacyPluralURL?: boolean;
+};
+export type K8sGroupVersionKind = { group?: string; version: string; kind: string };
+export type WatchK8sResource = {
+  groupVersionKind?: K8sGroupVersionKind;
+  name?: string;
+  namespace?: string;
+  isList?: boolean;
+  selector?: Selector;
+  namespaced?: boolean;
+  limit?: number;
+  fieldSelector?: string;
+  optional?: boolean;
+};
+export type WatchK8sResult<R extends K8sResourceCommon | K8sResourceCommon[]> = [R, boolean, any];
+
+/* ------------------ *
+ *  Internal Methods  *
+ * ------------------ */
+const getK8sResourcePath = (model: K8sModel, options: Options): string => {
+  let u = getK8sAPIPath(model);
+
+  if (options.ns) {
+    u += `/namespaces/${options.ns}`;
+  }
+  u += `/${model.plural}`;
+  if (options.name) {
+    // Some resources like Users can have special characters in the name.
+    u += `/${encodeURIComponent(options.name)}`;
+  }
+  if (options.path) {
+    u += `/${options.path}`;
+  }
+  if (!_.isEmpty(options.queryParams)) {
+    const q = _.map(options.queryParams, function(v, k) {
+      return `${k}=${v}`;
+    });
+    u += `?${q.join('&')}`;
+  }
+
+  return u;
+};
+const getK8sAPIPath = ({ apiGroup = 'core', apiVersion }: K8sModel): string => {
+  const isLegacy = apiGroup === 'core' && apiVersion === 'v1';
+  let p = isLegacy ? '/api/' : '/apis/';
+
+  if (!isLegacy && apiGroup) {
+    p += `${apiGroup}/`;
+  }
+
+  p += apiVersion;
+  return p;
+};
+const resourceURL = (model: K8sModel, options: Options): string =>
+  `${k8sBasePath}${getK8sResourcePath(model, options)}`;
+const adapterFunc = (func: Function, knownArgs: string[]) => {
+  return (options: Record<string, any>) => {
+    const args = knownArgs.map((arg) => {
+      // forming opts to match underlying API signature if it's there in knownArgs
+      if (arg === 'opts') {
+        const { name, ns, path, queryParams } = options || {};
+        return {
+          ...(name && { name }),
+          ...(ns && { ns }),
+          ...(path && { path }),
+          ...(queryParams && { queryParams }),
+        };
+      }
+      return options[arg];
+    });
+    return func(...args);
+  };
+};
+const toArray = (value) => (Array.isArray(value) ? value : [value]);
+const requirementToString = (requirement: MatchExpression): string => {
+  if (requirement.operator === 'Equals') {
+    return `${requirement.key}=${requirement.values[0]}`;
+  }
+
+  if (requirement.operator === 'NotEquals') {
+    return `${requirement.key}!=${requirement.values[0]}`;
+  }
+
+  if (requirement.operator === 'Exists') {
+    return requirement.key;
+  }
+
+  if (requirement.operator === 'DoesNotExist') {
+    return `!${requirement.key}`;
+  }
+
+  if (requirement.operator === 'In') {
+    return `${requirement.key} in (${toArray(requirement.values).join(',')})`;
+  }
+
+  if (requirement.operator === 'NotIn') {
+    return `${requirement.key} notin (${toArray(requirement.values).join(',')})`;
+  }
+
+  if (requirement.operator === 'GreaterThan') {
+    return `${requirement.key} > ${requirement.values[0]}`;
+  }
+
+  if (requirement.operator === 'LessThan') {
+    return `${requirement.key} < ${requirement.values[0]}`;
+  }
+
+  return '';
+};
+const createEquals = (key: string, value: string): MatchExpression => ({
+  key,
+  operator: 'Equals',
+  values: [value],
+});
+const isOldFormat = (selector: Selector | MatchLabels) =>
+  !selector.matchLabels && !selector.matchExpressions;
+const toRequirements = (selector: Selector = {}): MatchExpression[] => {
+  const requirements = [];
+  const matchLabels = isOldFormat(selector) ? selector : selector.matchLabels;
+  const { matchExpressions } = selector;
+
+  Object.keys(matchLabels || {})
+    .sort()
+    .forEach(function(k) {
+      requirements.push(createEquals(k, matchLabels[k]));
+    });
+
+  (matchExpressions || []).forEach(function(me) {
+    requirements.push(me);
+  });
+
+  return requirements;
+};
+const selectorToString = (selector: Selector): string => {
+  const requirements = toRequirements(selector);
+  return requirements.map(requirementToString).join(',');
+};
+
+const k8sGet = (
+  model: K8sModel,
+  name: string,
+  ns?: string,
+  opts?: Options,
+  requestInit?: RequestInit,
+) => coFetchJSON(resourceURL(model, Object.assign({ ns, name }, opts)), 'GET', requestInit);
+const k8sCreate = <R extends K8sResourceCommon>(
+  model: K8sModel,
+  data: R,
+  opts: Options = {},
+) => {
+  return coFetchJSON.post(
+    resourceURL(model, Object.assign({ ns: data?.metadata?.namespace }, opts)),
+    data,
+  );
+};
+const k8sUpdate = <R extends K8sResourceCommon>(
+  model: K8sModel,
+  data: R,
+  ns?: string,
+  name?: string,
+  opts?: Options,
+): Promise<R> =>
+  coFetchJSON.put(
+    resourceURL(model, {
+      ns: ns || data.metadata.namespace,
+      name: name || data.metadata.name,
+      ...opts,
+    }),
+    data,
+  );
+const k8sPatch = <R extends K8sResourceCommon>(
+  model: K8sModel,
+  resource: R,
+  data: Patch[],
+  opts: Options = {},
+) => {
+  const patches = _.compact(data);
+
+  if (_.isEmpty(patches)) {
+    return Promise.resolve(resource);
+  }
+
+  return coFetchJSON.patch(
+    resourceURL(
+      model,
+      Object.assign(
+        {
+          ns: resource.metadata.namespace,
+          name: resource.metadata.name,
+        },
+        opts,
+      ),
+    ),
+    patches,
+  );
+};
+const k8sKill = <R extends K8sResourceCommon>(
+  model: K8sModel,
+  resource: R,
+  opts: Options = {},
+  requestInit: RequestInit = {},
+  json: Record<string, any> = null,
+) => {
+  const { propagationPolicy } = model;
+  const jsonData =
+    json ?? (propagationPolicy && { kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy });
+  return coFetchJSON.delete(
+    resourceURL(
+      model,
+      Object.assign({ ns: resource.metadata.namespace, name: resource.metadata.name }, opts),
+    ),
+    jsonData,
+    requestInit,
+  );
+};
+const k8sList = (
+  model: K8sModel,
+  queryParams: { [key: string]: any } = {},
+  raw = false,
+  requestInit: RequestInit = {},
+) => {
+  const query = _.map(_.omit(queryParams, 'ns'), (v, k) => {
+    let newVal;
+    if (k === 'labelSelector') {
+      newVal = selectorToString(v);
+    }
+    return `${encodeURIComponent(k)}=${encodeURIComponent(newVal ?? v)}`;
+  }).join('&');
+
+  const listURL = resourceURL(model, { ns: queryParams.ns });
+  return coFetchJSON(`${listURL}?${query}`, 'GET', requestInit).then((result) => {
+    const typedItems = result.items?.map((i) => ({
+      kind: model.kind,
+      apiVersion: result.apiVersion,
+      ...i,
+    }));
+    return raw ? { ...result, items: typedItems } : typedItems;
+  });
+};
+
+/**
+ * This makes an assumption that the model will have a plural of `${kind}s` -- which is obv not ideal.
+ * Without apiDiscovery & the hook interface being sorta fixed, our options are limited.
+ */
+const makeGetCall = (resourceData: WatchK8sResource) => (
+  resourceData.groupVersionKind &&
+  k8sGetResource({
+    model: {
+      apiVersion: resourceData.groupVersionKind.version,
+      apiGroup: resourceData.groupVersionKind.group,
+      kind: resourceData.groupVersionKind.kind,
+      // TODO: no dictionary... solution?
+      plural: resourceData.groupVersionKind.kind.toLowerCase() + 's',
+    },
+    name: resourceData.name,
+    ns: resourceData.namespace,
+  })
+);
+/**
+ * This makes an assumption that the model will have a plural of `${kind}s` -- which is obv not ideal.
+ * Without apiDiscovery & the hook interface being sorta fixed, our options are limited.
+ */
+const makeListCall = (resourceData: WatchK8sResource) => (
+  resourceData.groupVersionKind &&
+  k8sListResource({
+    model: {
+      apiVersion: resourceData.groupVersionKind.version,
+      apiGroup: resourceData.groupVersionKind.group,
+      kind: resourceData.groupVersionKind.kind,
+      // TODO: no dictionary... solution?
+      plural: resourceData.groupVersionKind.kind.toLowerCase() + 's',
+    },
+    ...resourceData.namespace
+      ? {
+        queryParams: {
+          ns: resourceData.namespace,
+        }
+      }
+      : {},
+  })
+);
+
+const useDeepCompareMemoize = <T = any>(value: T, strinfigy?: boolean): T => {
+  const ref = React.useRef<T>();
+
+  if (
+    strinfigy
+      ? JSON.stringify(value) !== JSON.stringify(ref.current)
+      : !_.isEqual(value, ref.current)
+  ) {
+    ref.current = value;
+  }
+
+  return ref.current;
+};
+
+const useForceRender = () => React.useReducer((s: boolean) => !s, false)[1] as VoidFunction;
+
+/* ------------------ *
+ *  External Methods  *
+ * ------------------ */
+
+/**
+ * It fetches a resource from the cluster, based on the provided options.
+ * If the name is provided it returns one resource else it returns all the resources matching the model.
+ * @param options Which are passed as key-value pairs in the map
+ * @param options.model k8s model
+ * @param options.name The name of the resource, if not provided then it'll look for all the resources matching the model.
+ * @param options.ns The namespace to look into, should not be specified for cluster-scoped resources.
+ * @param options.path Appends as subpath if provided
+ * @param options.queryParams The query parameters to be included in the URL.
+ * @param options.requestInit The fetch init object to use. This can have request headers, method, redirect, etc.
+ * See more {@link https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html}
+ * @return A promise that resolves to the response as JSON object with a resource if the name is provided
+ * else it returns all the resources matching the model. In case of failure, the promise gets rejected with HTTP error response.
+ * * */
+export const k8sGetResource = adapterFunc(k8sGet, ['model', 'name', 'ns', 'opts', 'requestInit']);
+
+/**
+ * It creates a resource in the cluster, based on the provided options.
+ * @param options Which are passed as key-value pairs in the map
+ * @param options.model k8s model
+ * @param options.data payload for the resource to be created
+ * @param options.path Appends as subpath if provided
+ * @param options.queryParams The query parameters to be included in the URL.
+ * @return A promise that resolves to the response of the resource created.
+ * In case of failure promise gets rejected with HTTP error response.
+ * * */
+export const k8sCreateResource = adapterFunc(k8sCreate, ['model', 'data', 'opts']);
+
+/**
+ * It updates the entire resource in the cluster, based on provided options.
+ * When a client needs to replace an existing resource entirely, they can use k8sUpdate.
+ * Alternatively can use k8sPatch to perform the partial update.
+ * @param options which are passed as key-value pair in the map
+ * @param options.model k8s model
+ * @param options.data payload for the resource to be updated
+ * @param options.path Appends as subpath if provided
+ * @param options.queryParams The query parameters to be included in the URL.
+ * @return A promise that resolves to the response of the resource updated.
+ * In case of failure promise gets rejected with HTTP error response.
+ * * */
+export const k8sUpdateResource = adapterFunc(k8sUpdate, ['model', 'data', 'ns', 'name', 'opts']);
+
+/**
+ * It patches any resource in the cluster, based on provided options.
+ * When a client needs to perform the partial update, they can use k8sPatch.
+ * Alternatively can use k8sUpdate to replace an existing resource entirely.
+ * See more {@link https://datatracker.ietf.org/doc/html/rfc6902}
+ * @param options Which are passed as key-value pairs in the map.
+ * @param options.model k8s model
+ * @param options.resource The resource to be patched.
+ * @param options.data Only the data to be patched on existing resource with the operation, path, and value.
+ * @param options.path Appends as subpath if provided.
+ * @param options.queryParams The query parameters to be included in the URL.
+ * @return A promise that resolves to the response of the resource patched.
+ * In case of failure promise gets rejected with HTTP error response.
+ * * */
+export const k8sPatchResource = adapterFunc(k8sPatch, ['model', 'resource', 'data', 'opts']);
+
+/**
+ * It deletes resources from the cluster, based on the provided model, resource.
+ * The garbage collection works based on 'Foreground' | 'Background', can be configured with propagationPolicy property in provided model or passed in json.
+ * @param options which are passed as key-value pair in the map.
+ * @param options.model k8s model
+ * @param options.resource The resource to be deleted.
+ * @param options.path Appends as subpath if provided
+ * @param options.queryParams The query parameters to be included in the URL.
+ * @param options.requestInit The fetch init object to use. This can have request headers, method, redirect, etc.
+ * See more {@link https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html}
+ * @param options.json Can control garbage collection of resources explicitly if provided else will default to model's "propagationPolicy".
+ * @example
+ * { kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy }
+ * @return A promise that resolves to the response of kind Status.
+ * In case of failure promise gets rejected with HTTP error response.
+ * * */
+export const k8sDeleteResource = adapterFunc(k8sKill, [
+  'model',
+  'resource',
+  'opts',
+  'requestInit',
+  'json',
+]);
+
+/**
+ * It lists the resources as an array in the cluster, based on provided options.
+ * @param options Which are passed as key-value pairs in the map
+ * @param options.model k8s model
+ * @param options.queryParams The query parameters to be included in the URL and can pass label selector's as well with key "labelSelector".
+ * @param options.requestInit The fetch init object to use. This can have request headers, method, redirect, etc.
+ * See more {@link https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html}
+ * @return A promise that resolves to the response
+ * * */
+export const k8sListResource = adapterFunc(k8sList, ['model', 'queryParams', 'raw', 'requestInit']);
+
+
+/**
+ * Watch a resource -- works on a fixed delay poll today.
+ */
+export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCommon[]>(initResource: WatchK8sResource): WatchK8sResult<R> => {
+  const resource = useDeepCompareMemoize(initResource, true);
+  const resourceRef = React.useRef<R | null>(null);
+  const fetchedRef = React.useRef<boolean>(false);
+  const [error, setError] = React.useState<Error | null>(null);
+  const reRender = useForceRender();
+
+  React.useEffect(() => {
+    const addPromiseFollowups = (promise) => {
+      promise
+        ?.then((data) => {
+          if (data.kind === 'Status') {
+            if (resourceRef.current !== null) {
+              resourceRef.current = null;
+              reRender();
+            }
+          } else if (!_.isEqual(resourceRef.current, data)) {
+            resourceRef.current = data;
+            reRender();
+          }
+          fetchedRef.current = true;
+        })
+        .catch((err) => {
+          setError(err);
+          fetchedRef.current = false;
+        });
+    };
+    const makeTheCall = (r) => r.isList ? makeListCall(r) : makeGetCall(r);
+
+    addPromiseFollowups(makeTheCall(resource));
+    const intervalId = setInterval(() => {
+      addPromiseFollowups(makeTheCall(resource));
+    }, HOOK_POLL_DELAY);
+    return () => {
+      clearInterval(intervalId);
+    }
+  }, [resource]);
+
+  return [resourceRef.current, fetchedRef.current, error];
+};

--- a/frontend/src/poc-code/testK8s/dynamic-plugin-sdk.ts
+++ b/frontend/src/poc-code/testK8s/dynamic-plugin-sdk.ts
@@ -2,11 +2,15 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { HttpError } from './shared/utils/error/http-error';
+import { K8sTargetURL } from '../../../constants';
 
 const HOOK_POLL_DELAY = 2000; // change this if you want the useHook to go faster / slower on polls
 
 /* throw away fetch methods */
-const k8sBasePath = `/api/k8s`; // webpack proxy path
+/**
+ * The path to talk to K8s instance; either directly or through the dev webpack server.
+ */
+const k8sBasePath = process.env.NODE_ENV === 'production' ? K8sTargetURL : `/api/k8s`;
 
 export const validateStatus = async (
   response: Response

--- a/frontend/src/poc-code/testK8s/shared/utils/error/custom-error.ts
+++ b/frontend/src/poc-code/testK8s/shared/utils/error/custom-error.ts
@@ -1,0 +1,42 @@
+/**
+ * Allows to easily extend a base class to create custom applicative errors.
+ *
+ * example:
+ * ```
+ * class HttpError extends CustomError {
+ * 	public constructor(
+ * 		public code: number,
+ * 		message?: string,
+ * 	) {
+ * 		super(message)
+ * 	}
+ * }
+ *
+ * new HttpError(404, 'Not found')
+ * ```
+ */
+export class CustomError extends Error {
+  name: string;
+
+  constructor(message?: string) {
+    super(message);
+    // set error name as constructor name, make it not enumerable to keep native Error behavior
+    // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
+    Object.defineProperty(this, 'name', {
+      value: new.target.name,
+      enumerable: false,
+      configurable: true,
+    });
+    // Use captureStackTrace when available to remove contructor from stack trace
+    // Add message to the stack trace
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      this.stack = new Error(message).stack;
+    }
+    // fix the extended error prototype chain
+    // because typescript __extends implementation can't
+    // see https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/frontend/src/poc-code/testK8s/shared/utils/error/http-error.ts
+++ b/frontend/src/poc-code/testK8s/shared/utils/error/http-error.ts
@@ -1,0 +1,61 @@
+import { CustomError } from './custom-error';
+
+/**
+ * Http error
+ *
+ * Usage: throw HttpError.fromCode(404)
+ */
+export class HttpError extends CustomError {
+  protected static messages = {
+    400: 'Bad Request',
+    401: 'Unauthorized',
+    402: 'Payment Required',
+    403: 'Forbidden',
+    404: 'Not Found',
+    405: 'Method Not Allowed',
+    406: 'Not Acceptable',
+    407: 'Proxy Authentication Required', // RFC 7235
+    408: 'Request Timeout',
+    409: 'Conflict',
+    410: 'Gone',
+    411: 'Length Required',
+    412: 'Precondition Failed', // RFC 7232
+    413: 'Payload Too Large', // RFC 7231
+    414: 'URI Too Long', // RFC 7231
+    415: 'Unsupported Media Type',
+    416: 'Range Not Satisfiable', // RFC 7233
+    417: 'Expectation Failed',
+    418: "I'm a teapot", // RFC 2324
+    421: 'Misdirected Request', // RFC 7540
+    426: 'Upgrade Required',
+    428: 'Precondition Required', // RFC 6585
+    429: 'Too Many Requests', // RFC 6585
+    431: 'Request Header Fields Too Large', // RFC 6585
+    451: 'Unavailable For Legal Reasons', // RFC 7725
+    500: 'Internal Server Error',
+    501: 'Not Implemented',
+    502: 'Bad Gateway',
+    503: 'Service Unavailable',
+    504: 'Gateway Timeout',
+    505: 'HTTP Version Not Supported',
+    506: 'Variant Also Negotiates', // RFC 2295
+    510: 'Not Extended', // RFC 2774
+    511: 'Network Authentication Required', // RFC 6585
+  };
+
+  public constructor(message: string, public code?: number, public response?: Response, public json?: any) {
+    super(message);
+  }
+
+  public static fromCode(code: number) {
+    return new HttpError(HttpError.messages[code], code);
+  }
+}
+
+export class TimeoutError extends CustomError {
+  public constructor(public url: string, public ms: number) {
+    super(`Call to ${url} timed out after ${ms}ms.`);
+  }
+}
+
+export class RetryError extends CustomError {}


### PR DESCRIPTION
Adds a very crude test page to check if the token is properly pulled and used when calling the DevSandbox backend.

Do `yarn start:k8s` to use this functionality. 

**Note:** You'll need to get verified first before these calls are properly authed on your user.

Crude Page Screenshot (on `.../hac/testK8s` route):
![image](https://user-images.githubusercontent.com/8126518/151197778-a429386a-6750-494d-9369-ef0f413179e2.png)
