### PR TITLE
[HAC-454] Add custom dockerfile and nginx config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/*
+!.git/HEAD
+!.git/refs/heads
+!.git/objects
+./frontend/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM quay.io/redhat-cloud-services/releaser as build-stage
+WORKDIR /build
+COPY . ./
+RUN ./build.sh
+
+FROM registry.access.redhat.com/ubi8/nginx-118
+COPY ./nginx.conf /opt/app-root/etc/nginx/conf.d/default.conf
+COPY --from=build-stage /build/frontend/dist /opt/app-root/src
+ADD ./nginx.conf "${NGINX_CONFIGURATION_PATH}"
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,14 @@
+server {
+    listen 8000;
+    server_name hac-core;
+    error_log stderr;
+    access_log /dev/stdout;
+    root /opt/app-root/src/;
+    location / {
+      try_files $uri $uri/ /apps/chrome/index.html /beta/apps/chrome/index.html;
+    }
+    location ~* /apps/hac-core(.*) {
+      alias /opt/app-root/src;
+      try_files $1 $1/ /dist/$1 /dist/$1/;
+    }
+}


### PR DESCRIPTION
### Deploy hac-core as image

Since we want to adjust to the new pipeline of releasing frontend trough images we have to create custom dockerfile build with nginx. This PR adds both of them and utilizes previously used quay.io/redhat-cloud-services/releaser next step is to use PROW to deploy the new image to quay so frontend operator can use it.