### PR TITLE
Cleanup OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,9 +3,7 @@ reviewers:
   - BlakeHolifield
   - florkbr
   - fhlavac
-  - invincibleJai
   - karelhala
-  - ryelo
 approvers:
   - andrewballantyne
   - christianvogt


### PR DESCRIPTION
Dropping Jai as he is transitioning off the team and it will reduce auto-pick reviewers to him.

Ryan was not part of this effort before he moved most of his focus away from HAC-Core, so might as well drop him as well.