### PR TITLE
Allow plugin bootstrapping with __load_plugin_entry__ as well

### DIFF
--- a/frontend/@types/hac/index.d.ts
+++ b/frontend/@types/hac/index.d.ts
@@ -4,6 +4,7 @@ declare interface Window {
   windowError: any;
   loadPluginEntry: any;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: any;
+  __load_plugin_entry__: any;
 }
 
 declare const K8S_TARGET_URL: string;

--- a/frontend/src/poc-code/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
+++ b/frontend/src/poc-code/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
@@ -103,11 +103,13 @@ export const getPluginEntryCallback = (
 };
 
 export const registerPluginEntryCallback = (pluginStore: PluginStore) => {
-  window.loadPluginEntry = getPluginEntryCallback(
+  const loadPluginEntry = getPluginEntryCallback(
     pluginStore,
     initSharedPluginModules,
     resolveEncodedCodeRefs,
   );
+  window.__load_plugin_entry__ = loadPluginEntry;
+  window.loadPluginEntry = loadPluginEntry
 };
 
 export const loadPluginFromURL = async (baseURL: string) => {


### PR DESCRIPTION
## Bootstrap plugin with `__load_plugin_entry__`

Since new version of webpack plugin works only with `__load_plugin_entry__` let's expose this function on window as well.