### PR TITLE
Adjust Fetch calls URLs for Production Hosting

### DIFF
--- a/frontend/src/Utils/commonFetch.ts
+++ b/frontend/src/Utils/commonFetch.ts
@@ -59,7 +59,12 @@ export const commonFetch =
     };
 
     try {
-      return validateStatus(await fetch(new Request(`${k8sBasePath}${url}`, { credentials: 'include' }), allOptions));
+      let safeURL = url;
+      if (/^\/\//.test(url)) {
+        // https://github.com/openshift/dynamic-plugin-sdk/pull/55
+        safeURL = url.slice(1);
+      }
+      return validateStatus(await fetch(new Request(`${k8sBasePath}${safeURL}`, { credentials: 'include' }), allOptions));
     } catch (e) {
       return Promise.reject(e);
     }


### PR DESCRIPTION
The problem we had in the WS path hurts us on Production ... but not dev. So this is a fix for that half of the topic.

It seems Webpack DevServer handles the double slash -- straight URLs on staging do not:

![image](https://user-images.githubusercontent.com/8126518/157952312-bcbea554-5e94-4693-a820-1e89e933d499.png)
