### PR TITLE
Testing hook 'useK8sWatchResource' using testK8s

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@openshift/dynamic-plugin-sdk": "^1.0.0-alpha4",
-    "@openshift/dynamic-plugin-sdk-utils": "^1.0.0-alpha6",
+    "@openshift/dynamic-plugin-sdk-utils": "^1.0.0-alpha7",
     "@patternfly/patternfly": "^4.135.2",
     "@patternfly/quickstarts": "^1.3.0",
     "@patternfly/react-catalog-view-extension": "^4.12.74",

--- a/frontend/src/poc-code/testK8s/HookTest.tsx
+++ b/frontend/src/poc-code/testK8s/HookTest.tsx
@@ -35,10 +35,10 @@ const HookTest: React.FC<HookTestProps> = ({ namespace }) => {
   //   }
   // };
 
-  const [data, loaded, error] = useK8sWatchResource(watchedResource)
+  const [data, loaded, error] = useK8sWatchResource(watchedResource);
   const isResourceLoaded = loaded || !!error;
   if (isResourceLoaded) {
-    console.log("data from useK8sWatchResource: ", data);
+    console.log('data from useK8sWatchResource: ', data);
   }
 
   // TODO: The following code can be uncommented when we are ready to test the useK8sWatchResources hook

--- a/frontend/src/poc-code/testK8s/HookTest.tsx
+++ b/frontend/src/poc-code/testK8s/HookTest.tsx
@@ -11,7 +11,7 @@ type HookTestProps = {
 
 const HookTest: React.FC<HookTestProps> = ({ namespace }) => {
   const watchedResource = {
-    isList: true,
+    isList: false,
     groupVersionKind: {
       group: 'appstudio.redhat.com',
       version: 'v1alpha1',

--- a/frontend/src/poc-code/testK8s/HookTest.tsx
+++ b/frontend/src/poc-code/testK8s/HookTest.tsx
@@ -1,0 +1,74 @@
+/* eslint-disable no-console */
+import * as React from 'react';
+import { Title } from '@patternfly/react-core';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+
+/* This component is currently used to verify the useK8sWatchResource hook. */
+
+type HookTestProps = {
+  namespace: string;
+};
+
+const HookTest: React.FC<HookTestProps> = ({ namespace }) => {
+  const watchedResource = {
+    isList: true,
+    groupVersionKind: {
+      group: 'appstudio.redhat.com',
+      version: 'v1alpha1',
+      kind: 'Application',
+    },
+    name: 'test',
+    namespace,
+  };
+
+  // TODO: The following code can be uncommented when we are ready to test the useK8sWatchResources hook
+  // Only watching 'application' for now
+  // const watchedResources = {
+  //   application: {
+  //     isList: false,
+  //     groupVersionKind: {
+  //       group: 'appstudio.redhat.com',
+  //       version: 'v1alpha1',
+  //       kind: 'Application',
+  //     },
+  //     name: 'test',
+  //     namespace,
+  //   }
+  // };
+
+  const [data, loaded, error] = useK8sWatchResource(watchedResource)
+  const isResourceLoaded = loaded || !!error;
+  if (isResourceLoaded) {
+    console.log("data from useK8sWatchResource: ", data);
+  }
+
+  // TODO: The following code can be uncommented when we are ready to test the useK8sWatchResources hook
+  // const resources = useK8sWatchResources(watchedResources);
+  // const areResourcesLoaded =
+  //   Object.keys(resources).length > 0 &&
+  //   Object.values(resources).every((value) => value.loaded || !!value.loadError);
+  // const { resourcesData } = resources.application;
+  // if (areResourcesLoaded) {
+  //   console.log("data from useK8sWatchResources: ", resourcesData);
+  // }
+
+  return (
+    <>
+      <Title headingLevel="h2" size="xl">
+        Test hooks
+      </Title>
+      <div>
+        <p>Test useK8sWatchResource (watch Application)</p>
+        {!isResourceLoaded && <p>Loading resource...</p>}
+        {isResourceLoaded && <p>Resource loaded</p>}
+      </div>
+      {/* <div> TODO: This can be uncommented when we are ready to test the useK8sWatchResource hook
+        <p>Test useK8sWatchResources (watch Application)</p>
+        {!areResourcesLoaded && <p>Loading resource...</p>}
+        {areResourcesLoaded && <p>Resource loaded</p>}
+      </div>       */}
+    </>
+  );
+};
+
+export default HookTest;

--- a/frontend/src/poc-code/testK8s/HookTest.tsx
+++ b/frontend/src/poc-code/testK8s/HookTest.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import * as React from 'react';
-import { Title } from '@patternfly/react-core';
+import { Title, TextInput } from '@patternfly/react-core';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 
 /* This component is currently used to verify the useK8sWatchResource hook. */
@@ -10,6 +10,8 @@ type HookTestProps = {
 };
 
 const HookTest: React.FC<HookTestProps> = ({ namespace }) => {
+  const [name, setName] = React.useState<string>('test');
+
   const watchedResource = {
     isList: false,
     groupVersionKind: {
@@ -17,7 +19,7 @@ const HookTest: React.FC<HookTestProps> = ({ namespace }) => {
       version: 'v1alpha1',
       kind: 'Application',
     },
-    name: 'test',
+    name,
     namespace,
   };
 
@@ -54,12 +56,14 @@ const HookTest: React.FC<HookTestProps> = ({ namespace }) => {
   return (
     <>
       <Title headingLevel="h2" size="xl">
-        Test hooks
+        Test hooks to watch Application
       </Title>
+      <TextInput placeholder="Application name" onChange={(v) => setName(v)} value={name} />
       <div>
-        <p>Test useK8sWatchResource (watch Application)</p>
+        <p>Test useK8sWatchResource (watch Application: {name})</p>
         {!isResourceLoaded && <p>Loading resource...</p>}
-        {isResourceLoaded && <p>Resource loaded</p>}
+        {isResourceLoaded && data && <p>Resource loaded</p>}
+        {isResourceLoaded && !data && <p>No data -- did you create the Application?</p>}
       </div>
       {/* <div> TODO: This can be uncommented when we are ready to test the useK8sWatchResource hook
         <p>Test useK8sWatchResources (watch Application)</p>

--- a/frontend/src/poc-code/testK8s/HookTest.tsx
+++ b/frontend/src/poc-code/testK8s/HookTest.tsx
@@ -22,7 +22,6 @@ const HookTest: React.FC<HookTestProps> = ({ namespace }) => {
   };
 
   // TODO: The following code can be uncommented when we are ready to test the useK8sWatchResources hook
-  // Only watching 'application' for now
   // const watchedResources = {
   //   application: {
   //     isList: false,
@@ -47,9 +46,9 @@ const HookTest: React.FC<HookTestProps> = ({ namespace }) => {
   // const areResourcesLoaded =
   //   Object.keys(resources).length > 0 &&
   //   Object.values(resources).every((value) => value.loaded || !!value.loadError);
-  // const { resourcesData } = resources.application;
+  // const { data: resourceData } = resources.application;
   // if (areResourcesLoaded) {
-  //   console.log("data from useK8sWatchResources: ", resourcesData);
+  //   console.log("data from useK8sWatchResources: ", resourceData);
   // }
 
   return (
@@ -66,7 +65,7 @@ const HookTest: React.FC<HookTestProps> = ({ namespace }) => {
         <p>Test useK8sWatchResources (watch Application)</p>
         {!areResourcesLoaded && <p>Loading resource...</p>}
         {areResourcesLoaded && <p>Resource loaded</p>}
-      </div>       */}
+      </div> */}
     </>
   );
 };

--- a/frontend/src/poc-code/testK8s/TestK8s.tsx
+++ b/frontend/src/poc-code/testK8s/TestK8s.tsx
@@ -4,6 +4,7 @@ import { PageSection } from '@patternfly/react-core';
 import WSTest from './WSTest';
 import FetchTest from './FetchTest';
 import DetermineNamespace from './DetermineNamespace';
+import HookTest from './HookTest';
 
 const TestK8s: React.FC = () => {
   const [namespace, setNamespace] = React.useState<string>();
@@ -15,6 +16,8 @@ const TestK8s: React.FC = () => {
         <>
           <hr style={{ margin: 20 }} />
           <FetchTest namespace={namespace} />
+          <hr style={{ margin: 20 }} />
+          <HookTest namespace={namespace}/>
           <hr style={{ margin: 20 }} />
           <WSTest namespace={namespace} />
         </>

--- a/frontend/src/poc-code/testK8s/TestK8s.tsx
+++ b/frontend/src/poc-code/testK8s/TestK8s.tsx
@@ -17,7 +17,7 @@ const TestK8s: React.FC = () => {
           <hr style={{ margin: 20 }} />
           <FetchTest namespace={namespace} />
           <hr style={{ margin: 20 }} />
-          <HookTest namespace={namespace}/>
+          <HookTest namespace={namespace} />
           <hr style={{ margin: 20 }} />
           <WSTest namespace={namespace} />
         </>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -551,10 +551,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openshift/dynamic-plugin-sdk-utils@^1.0.0-alpha6":
-  version "1.0.0-alpha6"
-  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk-utils/-/dynamic-plugin-sdk-utils-1.0.0-alpha6.tgz#9ee9457989327331975b38d7111195e5f5ec49a0"
-  integrity sha512-EHbUvDO7tug7Hl4NQABx8QGkDAT9eTCty8La/3Hk6jZbc2f+jC3zNTG20Mb8bU58/O0K+gA0eO6biW9rchlbNA==
+"@openshift/dynamic-plugin-sdk-utils@^1.0.0-alpha7":
+  version "1.0.0-alpha7"
+  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk-utils/-/dynamic-plugin-sdk-utils-1.0.0-alpha7.tgz#f8529ef391c570d8c7336dec65c8051161ef6c7e"
+  integrity sha512-qjqjcCaPz7KCXzl0zoctqRFQCGhjO+XU4DOD/XwvQB1+JZS6B05Qmp+Arc1FKRUBQ0s93owKUpTGn2kj7arDOA==
   dependencies:
     immutable "^3.8.2"
     lodash-es "^4.17.21"


### PR DESCRIPTION
HookTest is a component for verifying the the `useK8sWatchResource` and `useK8sWatchResources` hooks. 

The code for verifying the plural hook `useK8sWatchResources` is currently commented out (see comments marked with TODO in `frontend/src/poc-code/testK8s/HookTest.tsx`) as this hook is not merged into the SDK yet.

To test:
```
cd frontend
yarn install
ENVIRONMENT=prod yarn dev
```
In the browser, open: https://prod.foo.redhat.com:1337/beta/hac/testK8s

<img width="936" alt="Screen Shot 2022-04-13 at 4 09 24 PM" src="https://user-images.githubusercontent.com/43621546/163262249-e3bd01a4-6ffc-4c2f-872f-f8742c473337.png">
<img width="825" alt="Screen Shot 2022-04-13 at 4 10 35 PM" src="https://user-images.githubusercontent.com/43621546/163262247-0834bd16-d6f5-4b4c-bfbe-27343bd77172.png">
