### PR TITLE
Add ENV_NAME as param for deployment

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -12,7 +12,7 @@ objects:
       versions:
         - v1
     deploymentRepo: 'http://test'
-    envName: ephem-hac
+    envName: ${ENV_NAME}
     frontend:
       paths:
         - /apps/hac-core
@@ -34,3 +34,5 @@ parameters:
     value: latest
   - name: IMAGE
     value: quay.io/cloudservices/hac-core-frontend
+  - name: ENV_NAME
+    value: ephem-hac


### PR DESCRIPTION
Enables us to deploy hac-core to the ephemeral env with the correct ephemeral environment configured. 