### PR TITLE
Mark react router dom as singleton to share provider instance

### DIFF
--- a/frontend/config/plugins.js
+++ b/frontend/config/plugins.js
@@ -15,7 +15,7 @@ const plugins = [
       './Navigation': resolve(__dirname, '../src/Navigation'),
     },
     shared: [
-      { 'react-router-dom': { requiredVersion: package.dependencies['react-router-dom'] } },
+      { 'react-router-dom': { singleton: true, requiredVersion: package.dependencies['react-router-dom'] } },
       { 'react-redux': { singleton: true, requiredVersion: package.dependencies['react-redux'] } },
       { '@openshift/dynamic-plugin-sdk-utils': { singleton: true, requiredVersion: package.dependencies['@openshift/dynamic-plugin-sdk-utils'] } },
       { '@openshift/dynamic-plugin-sdk': { singleton: true, requiredVersion: package.dependencies['@openshift/dynamic-plugin-sdk'] } },


### PR DESCRIPTION
## Description

Let's put back the singleton, removing it was just a placeholder so hac-core won't fail completely when running with hac-dev. Currently some pages of hac-dev are working, places where the app needs to access react-router provider fails due to mismatch instances.

## Checklist:

- [x] merge after https://github.com/openshift/hac-dev/pull/129