### PR TITLE
Add model feature flag extension watcher

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Routes } from './Routes';
-import './App.scss';
-
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { useStore } from 'react-redux';
 import { RegistryContext } from './store';
-import { isFeatureFlag, useResolvedExtensions } from '@openshift/dynamic-plugin-sdk';
+import { isFeatureFlag, isModelFeatureFlag, useExtensions, useResolvedExtensions } from '@openshift/dynamic-plugin-sdk';
 import FeatureFlagLoader from './Utils/FeatureFlagLoader';
+import ModelFeatureFlagLoader from './Utils/ModelFeatureFlagLoader';
 
 const App: React.FC = () => {
   const navigate = useNavigate();
   const { getRegistry } = React.useContext(RegistryContext);
   const [featureExtension] = useResolvedExtensions(isFeatureFlag);
+  const extensions = useExtensions(isModelFeatureFlag);
 
   const chrome = useChrome();
   const store = useStore();
@@ -37,6 +37,9 @@ const App: React.FC = () => {
     <React.Fragment>
       {featureExtension.map((extension) => (
         <FeatureFlagLoader {...extension.properties} key={extension.uid} />
+      ))}
+      {extensions.map((extension) => (
+        <ModelFeatureFlagLoader {...extension.properties} key={extension.uid} />
       ))}
       <NotificationsPortal store={store} />
       <Routes />

--- a/frontend/src/Routes/testK8s/DetermineNamespace.tsx
+++ b/frontend/src/Routes/testK8s/DetermineNamespace.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { isUtilsConfigSet, k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
-import { ProjectModel } from './models';
 import { Alert, Spinner } from '@patternfly/react-core';
+import { ProjectModel } from '../../Utils/types';
 
 type DetermineNamespaceProps = {
   namespace: string;

--- a/frontend/src/Routes/testK8s/models.ts
+++ b/frontend/src/Routes/testK8s/models.ts
@@ -1,12 +1,5 @@
 import { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
 
-export const ProjectModel: K8sModelCommon = {
-  apiVersion: 'v1',
-  apiGroup: 'project.openshift.io',
-  kind: 'Project',
-  plural: 'projects',
-};
-
 export const ApplicationModel: K8sModelCommon = {
   apiVersion: 'v1alpha1',
   kind: 'Application',

--- a/frontend/src/Utils/ModelFeatureFlagLoader.tsx
+++ b/frontend/src/Utils/ModelFeatureFlagLoader.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
+import { useK8sModel } from '@openshift/dynamic-plugin-sdk-utils';
+
+export type ModelFeatureFlagLoaderProps = {
+  flag: string;
+  model: {
+    group: string;
+    version: string;
+    kind: string;
+  };
+};
+
+/**
+ * Component to wrap setting and loading of model feature flag.
+ * @param ModelFeatureFlagLoaderProps which model and feature flag to set for given namespace.
+ * @returns null
+ */
+const ModelFeatureFlagLoader: React.FC<ModelFeatureFlagLoaderProps> = ({ flag, model }) => {
+  const [, setFlag] = useFeatureFlag(flag);
+  const [data] = useK8sModel(model);
+
+  React.useEffect(() => {
+    setFlag(!!data);
+  }, [data, setFlag]);
+
+  return null;
+};
+
+export default React.memo(ModelFeatureFlagLoader);

--- a/frontend/src/Utils/types.ts
+++ b/frontend/src/Utils/types.ts
@@ -1,0 +1,8 @@
+import type { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
+
+export const ProjectModel: K8sModelCommon = {
+  apiVersion: 'v1',
+  apiGroup: 'project.openshift.io',
+  kind: 'Project',
+  plural: 'projects',
+};


### PR DESCRIPTION
### Description

SDK supports both model and flag extensions, this PR consumes the model extensions and sets their value based on active model in redux state.