### PR TITLE
impose tsconfig strict = true

### DIFF
--- a/frontend/@types/hac/index.d.ts
+++ b/frontend/@types/hac/index.d.ts
@@ -11,3 +11,8 @@ declare const K8S_TARGET_URL: string;
 declare const K8S_WS_TARGET_URL: string;
 
 declare const __webpack_init_sharing__: Function;
+
+// fix implicit any errors for modules without typings
+declare module "@redhat-cloud-services/frontend-components-notifications/NotificationPortal";
+declare module "@redhat-cloud-services/frontend-components-notifications/redux";
+declare module "@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,6 +71,7 @@
     "@types/jest": "^27.5.1",
     "@types/react-redux": "7.x",
     "@types/react-router-dom": "^5.3.2",
+    "@types/redux-logger": "3.0.6",
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.0.0",
     "enzyme": "3.11.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,7 +23,7 @@ const App: React.FC = () => {
     getRegistry().register({ notifications: notificationsReducer });
     const { on: onChromeEvent } = chrome?.init();
 
-    const unregister = onChromeEvent('APP_NAVIGATION', (event) => {
+    const unregister = onChromeEvent('APP_NAVIGATION', (event: any) => {
       if (event.domEvent) {
         navigate(`${event.domEvent.href.replace('/hac', '')}`);
       }
@@ -31,7 +31,7 @@ const App: React.FC = () => {
     return () => {
       unregister();
     };
-  }, [history, chrome]);
+  }, [chrome, getRegistry, navigate]);
 
   return (
     <React.Fragment>

--- a/frontend/src/Routes/testK8s/DetermineNamespace.tsx
+++ b/frontend/src/Routes/testK8s/DetermineNamespace.tsx
@@ -4,12 +4,12 @@ import { ProjectModel } from './models';
 import { Alert, Spinner } from '@patternfly/react-core';
 
 type DetermineNamespaceProps = {
-  namespace: string;
+  namespace?: string;
   setNamespace: (namespace: string) => void;
 };
 
 const DetermineNamespace: React.FC<DetermineNamespaceProps> = ({ namespace, setNamespace }) => {
-  const [error, setError] = React.useState<string>(null);
+  const [error, setError] = React.useState<string>();
 
   const hasConfig = isUtilsConfigSet();
   React.useEffect(() => {
@@ -18,7 +18,7 @@ const DetermineNamespace: React.FC<DetermineNamespaceProps> = ({ namespace, setN
         model: ProjectModel,
       })
         .then((items) => {
-          const ns = items[0]?.metadata.name;
+          const ns = items[0]?.metadata?.name;
 
           if (ns) {
             setNamespace(ns);

--- a/frontend/src/Routes/testK8s/FetchTest.tsx
+++ b/frontend/src/Routes/testK8s/FetchTest.tsx
@@ -27,11 +27,11 @@ type FetchTestProps = {
 };
 
 const FetchTest: React.FC<FetchTestProps> = ({ namespace }) => {
-  const [r, setR] = React.useState(null);
+  const [r, setR] = React.useState<K8sResourceCommon>();
   const [name, setName] = React.useState<string>('test');
   const [status, setStatus] = React.useState<string>('');
-  const [action, setAction] = React.useState<ActionType | null>(null);
-  const [resourceVersion, setResourceVersion] = React.useState<string>(null);
+  const [action, setAction] = React.useState<ActionType>();
+  const [resourceVersion, setResourceVersion] = React.useState<string>();
 
   React.useEffect(() => {
     const testApplicationMetadata = {
@@ -116,10 +116,10 @@ const FetchTest: React.FC<FetchTestProps> = ({ namespace }) => {
       .catch((err) => {
         console.error(`++++failed ${action}`, err);
         setStatus(`failed call: ${err.message}`);
-        setR(null);
+        setR(undefined);
       })
       .finally(() => {
-        setAction(null); // prevent the hook for re-firing on name change
+        setAction(undefined); // prevent the hook for re-firing on name change
       });
   }, [action, name, namespace, resourceVersion]);
 

--- a/frontend/src/Routes/testK8s/PrintObject.tsx
+++ b/frontend/src/Routes/testK8s/PrintObject.tsx
@@ -8,24 +8,15 @@ type PrintObjectProps = {
 const PrintObject: React.FC<PrintObjectProps> = ({ object }) => {
   const [expanded, setExpanded] = React.useState(false);
 
-  const sanitize = (resourceOrResourceList) => {
-    if (Array.isArray(resourceOrResourceList)) {
-      return resourceOrResourceList.map(sanitize);
-    }
-
+  const sanitize = (resourceOrResourceList: K8sResourceCommon): K8sResourceCommon => {
     const {
-      apiVersion,
-      kind,
-      apiGroup,
+      // @ts-ignore add `managedFields` to K8sResourceCommon
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       metadata: { managedFields, ...metadata }, // drop managedFields
       ...resource
     } = resourceOrResourceList;
 
     return {
-      apiVersion,
-      kind,
-      apiGroup,
       metadata,
       ...resource,
     };

--- a/frontend/src/Routes/testK8s/WSTest.tsx
+++ b/frontend/src/Routes/testK8s/WSTest.tsx
@@ -12,19 +12,18 @@ type WSTestProps = {
 
 const WSTest: React.FC<WSTestProps> = ({ namespace }) => {
   const [r, setR] = React.useState(null);
-  const [error, setError] = React.useState(null);
+  const [error, setError] = React.useState<string | null>(null);
   const [isOpen, setOpen] = React.useState(false);
   const [path, setPath] = React.useState<string>();
 
   React.useEffect(() => {
-    let ws: WebSocketFactory;
     if (path) {
       let safePath = path;
       if (/^\/\//.test(path)) {
         // https://github.com/openshift/dynamic-plugin-sdk/pull/55
         safePath = path.slice(1);
       }
-      ws = new WebSocketFactory('sample websocket', {
+      const ws = new WebSocketFactory('sample websocket', {
         path: safePath,
       });
       ws.onOpen(() => {
@@ -64,12 +63,10 @@ const WSTest: React.FC<WSTestProps> = ({ namespace }) => {
         // 1006: https://stackoverflow.com/a/19305172
         console.debug('close', data, 'code:', data.code);
       });
+      return () => {
+        ws.destroy();
+      };
     }
-
-    return () => {
-      ws?.destroy();
-      ws = null;
-    };
   }, [path]);
 
   return (

--- a/frontend/src/Utils/FeatureFlagLoader.tsx
+++ b/frontend/src/Utils/FeatureFlagLoader.tsx
@@ -10,7 +10,7 @@ export type ModelFeatureFlagLoaderProps = {
  * @param function function that accepts single argmunet of type SetFeatureFlag callback.
  * @returns null
  */
-const FeatureFlagLoader = ({ handler }) => {
+const FeatureFlagLoader: React.FC<ModelFeatureFlagLoaderProps> = ({ handler }) => {
   const pluginStore = usePluginStore();
   const setFlagCallback = React.useCallback(
     (name, value) => {

--- a/frontend/src/bootstrap.tsx
+++ b/frontend/src/bootstrap.tsx
@@ -4,4 +4,4 @@ import AppEntry from './AppEntry';
 
 const root = document.getElementById('root');
 
-render(<AppEntry />, root, () => root.setAttribute('data-ouia-safe', 'true'));
+render(<AppEntry />, root, () => root!.setAttribute('data-ouia-safe', 'true'));

--- a/frontend/src/sdk/commonFetch.ts
+++ b/frontend/src/sdk/commonFetch.ts
@@ -48,7 +48,7 @@ export const validateStatus = async (response: Response) => {
 
 export const commonFetch =
   (auth: AuthConfig) =>
-  async (url: string, { pathPrefix, ...options }: RequestInit & { pathPrefix?: string }): Promise<Response> => {
+  async (url: string, { pathPrefix, ...options }: RequestInit & { pathPrefix?: string } = {}): Promise<Response> => {
     const token = await auth.getToken();
     if (!token) {
       return Promise.reject('Could not make k8s call. Unable to find token.');

--- a/frontend/src/sdk/createStore.ts
+++ b/frontend/src/sdk/createStore.ts
@@ -2,7 +2,7 @@ import { getActivePlugins } from '../Utils/plugins';
 import packageInfo from '../../package.json';
 import { PluginLoader, PluginLoaderOptions, PluginStore } from '@openshift/dynamic-plugin-sdk';
 
-const modules = {
+const modules: { [name: string]: () => Promise<() => any> } = {
   '@openshift/dynamic-plugin-sdk-utils': async () => () => require('@openshift/dynamic-plugin-sdk-utils'),
   '@openshift/dynamic-plugin-sdk': async () => () => require('@openshift/dynamic-plugin-sdk'),
   '@patternfly/react-core': async () => () => require('@patternfly/react-core'),

--- a/frontend/src/sdk/customError.ts
+++ b/frontend/src/sdk/customError.ts
@@ -16,8 +16,6 @@
  * ```
  */
 export class CustomError extends Error {
-  name: string;
-
   constructor(message?: string) {
     super(message);
     // set error name as constructor name, make it not enumerable to keep native Error behavior

--- a/frontend/src/sdk/httpError.ts
+++ b/frontend/src/sdk/httpError.ts
@@ -6,7 +6,7 @@ import { CustomError } from './customError';
  * Usage: throw HttpError.fromCode(404)
  */
 export class HttpError extends CustomError {
-  protected static messages = {
+  protected static messages: { [code: number]: string } = {
     400: 'Bad Request',
     401: 'Unauthorized',
     402: 'Payment Required',

--- a/frontend/src/sdk/useAppConfiguration.ts
+++ b/frontend/src/sdk/useAppConfiguration.ts
@@ -34,7 +34,7 @@ const useAppConfiguration = (): AppConfigurations | null => {
         pluginStore,
       });
     }
-  }, [appConfigurations, pluginStore, auth]);
+  }, [appConfigurations, auth]);
 
   return appConfigurations;
 };

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -4,7 +4,7 @@ import promiseMiddleware from 'redux-promise-middleware';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
 import { SDKReducers } from '@openshift/dynamic-plugin-sdk-utils';
 import thunk from 'redux-thunk';
-import type { Store } from 'redux';
+import type { Middleware, Store } from 'redux';
 
 export type Registry = {
   getStore: () => Store;
@@ -15,11 +15,11 @@ export type ContextRegistry = {
   getRegistry: () => Registry;
 };
 
-export const RegistryContext = createContext<ContextRegistry>(undefined);
+export const RegistryContext = createContext<ContextRegistry>({} as ContextRegistry);
 
 let registry: Registry;
 
-export function init(...middleware): Registry {
+export function init(...middleware: Middleware[]): Registry {
   registry = getRegistry(
     {},
     [thunk, promiseMiddleware, notificationsMiddleware({ errorDescriptionKey: ['detail', 'stack'] }), ...middleware.filter(Boolean)],

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,7 +18,8 @@
     },
     "typeRoots": ["node_modules/@types", "@types"],
     "types": ["node", "jest"],
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   },
   "exclude": [
     "**/node_modules",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1351,6 +1351,13 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/redux-logger@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/redux-logger/-/redux-logger-3.0.6.tgz#4cf9d5b596b576b030a4bb671547f0ab63f81a73"
+  integrity sha512-HXVJnbyuTcVtQ+qiwDcbLEMoOgNjKnNYVKx29P4NhV+FIgVVRCFILEPzjgSxlmMLc6aBVaEew7PfE3421DZ6Jw==
+  dependencies:
+    redux "^3.6.0"
+
 "@types/retry@^0.12.0":
   version "0.12.1"
   resolved "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz"
@@ -5528,7 +5535,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.21:
+lodash-es@^4.17.21, lodash-es@^4.2.1:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
@@ -5563,7 +5570,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz"
   integrity "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM= sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
 
-lodash@^4.17.0, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.0, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.2.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6959,6 +6966,16 @@ redux@4.1.0, redux@>=4.0.5, redux@^4.0.0:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
+redux@^3.6.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  integrity sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
+
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz"
@@ -7843,6 +7860,11 @@ svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz"
   integrity "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q= sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA=="
+
+symbol-observable@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
Update tsconfig with `strict: true`.

HAC repos do not enable strict typescript options such as `strictNullCheck`. This can lead to developers assuming a value is present and not doing proper null checks.

The best use of typescript is when we are very strict on types without burdening the developer.