### PR TITLE
Revert "Add hac-build-service plugin to hac-core"

### DIFF
--- a/frontend/config/dev.webpack.config.js
+++ b/frontend/config/dev.webpack.config.js
@@ -73,7 +73,6 @@ const webpackProxy = {
       pathRewrite: { '^/api/k8s': '' },
     },
     pluginProxy('hac-dev'),
-    pluginProxy('hac-build-service'),
     pluginProxy('hac-infra'),
     {
       context: (path) => path.includes('/wss/k8s'),

--- a/frontend/static/plugins.json
+++ b/frontend/static/plugins.json
@@ -1,1 +1,1 @@
-[{ "name": "hac-dev" }, { "name": "hac-build-service" }, { "name": "hac-infra" }]
+[{ "name": "hac-dev" }, { "name": "hac-infra" }]


### PR DESCRIPTION
This reverts commit 15690915b787f5f867ce484f3533578dca56f6f6. (https://github.com/openshift/hac-core/pull/75)

HAC build service will no longer be a standalone plugin to HAC - it will be exposed through hac-dev.

Part of https://issues.redhat.com/browse/HAC-1813