### PR TITLE
Wrap each route with PageSection element

### DIFF
--- a/frontend/src/Routes/DynamicRoute/DynamicRoute.tsx
+++ b/frontend/src/Routes/DynamicRoute/DynamicRoute.tsx
@@ -7,7 +7,7 @@ import {
   isContextProvider,
   useResolvedExtensions,
 } from '@openshift/dynamic-plugin-sdk';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Bullseye, Spinner, PageSection } from '@patternfly/react-core';
 import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
 import camelCase from 'lodash/camelCase';
 import ProviderWrapper from '../../Utils/ProviderWrapper';
@@ -71,9 +71,9 @@ const DynamicRoute: React.FC<DynamicRouteProps> = () => {
                 {...currCoute}
                 key={uid}
                 element={
-                  <article className={className}>
+                  <PageSection className={`${className} pf-m-no-padding`}>
                     <Component />
-                  </article>
+                  </PageSection>
                 }
               />
             ))}

--- a/frontend/src/Routes/testK8s/FetchTest.tsx
+++ b/frontend/src/Routes/testK8s/FetchTest.tsx
@@ -30,7 +30,7 @@ const FetchTest: React.FC<FetchTestProps> = ({ namespace }) => {
   const [r, setR] = React.useState<K8sResourceCommon>();
   const [name, setName] = React.useState<string>('test');
   const [status, setStatus] = React.useState<string>('');
-  const [action, setAction] = React.useState<ActionType>();
+  const [action, setAction] = React.useState<ActionType | undefined | null>(null);
   const [resourceVersion, setResourceVersion] = React.useState<string>();
 
   React.useEffect(() => {


### PR DESCRIPTION
### Description

Chrome is taking care of the content and wraps each route with flex layout. In order to span each route to the whole content we have to use `PageSection` component to allign with the chroming layout.

### Screenshot

![Screenshot from 2022-08-09 11-14-01](https://user-images.githubusercontent.com/3439771/183611946-d9a08e1a-c19b-48f1-bb24-044ba52fbe8c.png)

