### PR TITLE
Temporarily disable hac-infra plugin while investigating prod issue

### DIFF
--- a/frontend/static/plugins.json
+++ b/frontend/static/plugins.json
@@ -1,1 +1,1 @@
-[{ "name": "hac-dev" }, { "name": "hac-infra" }]
+[{ "name": "hac-dev" }]


### PR DESCRIPTION
Feel free to merge/revert while we investigate. Right now my theory is there may be a race condition as to why we see hac-dev load locally versus on production. It seems to me that an unhandled error in https://github.com/openshift/hac-core/blob/main/frontend/src/Navigation.ts#L57 could be causing the stack to crash - as I don't see any obvious issues with https://github.com/openshift/hac-core/blob/main/frontend/src/sdk/createStore.ts#L45 (`pluginStore.loadPlugin` is never called for any plugins). 