### PR TITLE
Improve the getActivePlugins utility and add tests

### DIFF
--- a/frontend/config/setupTests.ts
+++ b/frontend/config/setupTests.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import { enableFetchMocks } from 'jest-fetch-mock';
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
@@ -7,3 +8,5 @@ jest.mock('react', () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 Element.prototype.scrollTo = () => {};
+
+enableFetchMocks();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "27.0.5",
+    "jest-fetch-mock": "^3.0.3",
     "prop-types": "15.7.2",
     "stylelint": "13.13.1",
     "stylelint-config-recommended-scss": "4.2.0",

--- a/frontend/src/Utils/plugins.test.ts
+++ b/frontend/src/Utils/plugins.test.ts
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+import { getActivePlugins } from './plugins';
+import fetch from 'jest-fetch-mock';
+
+describe('getActivePlugins function tests', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error');
+    fetch.resetMocks();
+  });
+
+  afterEach(() => {
+    fetch.resetMocks();
+  });
+
+  test('should catch and log error if response is not of type application/json', async () => {
+    fetch.mockResponseOnce('text', { headers: { 'content-type': 'application/text' } });
+    const result = await getActivePlugins(true, 'foobar');
+    expect(result).toMatchObject([]);
+    expect(console.error).toHaveBeenCalledWith('Failed to fetch plugin data', new Error('plugin data response is not type application/json'));
+  });
+
+  test('should catch and log error if fetch fails', async () => {
+    const error = new Error('An unexpected error has occured');
+    fetch.mockRejectOnce(error);
+    const result = await getActivePlugins(true, 'foobar');
+    expect(result).toMatchObject([]);
+    expect(console.error).toHaveBeenCalledWith('Failed to fetch plugin data', error);
+  });
+
+  test('should return list of plugins on success', async () => {
+    const plugins = [{ name: 'cool-plugin' }];
+    fetch.mockResponseOnce(JSON.stringify(plugins), { headers: { 'content-type': 'application/json' } });
+    const result = await getActivePlugins(true, 'foobar');
+    expect(console.error).not.toHaveBeenCalled();
+    expect(result).toMatchObject(plugins);
+  });
+
+  test('should toggle /beta in URL with isBeta param', async () => {
+    const plugins = [{ name: 'cool-plugin' }];
+    const appName = 'foobar';
+    fetch.mockResponse(JSON.stringify(plugins), { headers: { 'content-type': 'application/json' } });
+    await getActivePlugins(false, appName);
+    expect(console.error).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledWith(`/apps/${appName}/plugins.json`);
+    await getActivePlugins(true, appName);
+    expect(console.error).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledWith(`/beta/apps/${appName}/plugins.json`);
+  });
+});

--- a/frontend/src/Utils/plugins.ts
+++ b/frontend/src/Utils/plugins.ts
@@ -7,7 +7,12 @@ type GetActivePlugins = (isBeta: boolean, appName: string) => Promise<PluginType
 
 export const getActivePlugins: GetActivePlugins = async (isBeta, appName) => {
   try {
-    return (await fetch(`${isBeta ? '/beta' : ''}/apps/${appName}/plugins.json`)).json();
+    const response = await fetch(`${isBeta ? '/beta' : ''}/apps/${appName}/plugins.json`);
+    const isJson = response.headers.get('content-type')?.includes('application/json');
+    if (!isJson) {
+      throw new Error('plugin data response is not type application/json');
+    }
+    return await response.json();
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error('Failed to fetch plugin data', e);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2720,6 +2720,13 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-fetch@^3.0.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz"
@@ -5015,6 +5022,14 @@ jest-environment-node@^27.3.1:
     jest-mock "^27.3.0"
     jest-util "^27.3.1"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^27.3.1, jest-get-type@^27.5.1:
   version "27.5.1"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz"
@@ -6621,6 +6636,11 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-polyfill@^8.1.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.3.tgz#2edc7e4b81aff781c88a0d577e5fe9da822107c6"
+  integrity sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==
 
 prompts@^2.0.1:
   version "2.4.2"


### PR DESCRIPTION
While investigating the issues around hac-dev not loading on https://console.dev.redhat.com/hac/app-studio, we noticed that it is possible for our API to return 404 HTML when we are requesting the plugin.json file.

For example, see:
https://console.dev.redhat.com/apps/hac-core/plugins.json vs https://console.dev.redhat.com/beta/apps/hac-core/plugins.json (note the `/beta` difference in the URL).  The `/beta` URL is returning a 404 error page and we instantiate the plugin store with an empty array.

For ease of debugging in the future, I'd like to clearly log when this happens - as it's not trivial to see at first glance. 