### PR TITLE
Flip isBeta to false when initializing the store

### DIFF
--- a/frontend/src/sdk/createStore.ts
+++ b/frontend/src/sdk/createStore.ts
@@ -42,7 +42,7 @@ export const createStore = () => {
   pluginLoader.registerPluginEntryCallback();
   const pluginStore = new PluginStore();
   pluginStore.setLoader(pluginLoader);
-  getActivePlugins(true, packageInfo.insights.appname).then((data) => {
+  getActivePlugins(false, packageInfo.insights.appname).then((data) => {
     data.forEach(({ name: item, pathPrefix = '/api/plugins' }) => {
       const url = `/beta${pathPrefix}/${item}/`;
       pluginStore.loadPlugin(url);


### PR DESCRIPTION
We have `isBeta` hard-coded in the `createStore` logic.

I wanted to pull `isBeta` from our `useChrome` hook exposed by the consoledot chrome APIs, however - since `createStore` is not a react component it cannot be used. A valid use can be seen here: https://github.com/openshift/hac-core/blob/main/frontend/src/sdk/useActivePlugins.ts#L7

I can technically pass it in from the caller component, but I'm worried the store may be re-created multiple times (right now it's only evaluated once).

For the time being in order to unblock the team I've opened this PR. I will discuss with the core team next week