### PR TITLE
Bump lib-utils SDK package to 1.0.0 to pick up hac-infra components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@openshift/dynamic-plugin-sdk": "^1.0.0-alpha16",
-    "@openshift/dynamic-plugin-sdk-utils": "^1.0.0-alpha19",
+    "@openshift/dynamic-plugin-sdk-utils": "^1.0.0",
     "@patternfly/patternfly": "^4.185.1",
     "@patternfly/quickstarts": "^2.2.1",
     "@patternfly/react-catalog-view-extension": "^4.53.16",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -607,10 +607,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openshift/dynamic-plugin-sdk-utils@^1.0.0-alpha19":
-  version "1.0.0-alpha19"
-  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk-utils/-/dynamic-plugin-sdk-utils-1.0.0-alpha19.tgz#94edcf335b627033426fa8b679e68d957492a832"
-  integrity sha512-iVJsvgUw+dJRS72Ox7W03yg94w15GqMd4KdIvwaqDQPBJHygml5lcPi0gRIah3Wj7CaGFhaa3lfd+XNwIan1TQ==
+"@openshift/dynamic-plugin-sdk-utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk-utils/-/dynamic-plugin-sdk-utils-1.0.0.tgz#dd73ffcb712e58d25fef89b95377265ca17d9b13"
+  integrity sha512-ZXEJFFGixA1rQj6HKsFJ2q/xeumxCKvmITGIlgMtJwlXbPJQZZ2X5dWv2xazSbjsZotGqM1NX8okH1q5Xwv4oQ==
   dependencies:
     immutable "^3.8.2"
     lodash-es "^4.17.21"


### PR DESCRIPTION
PR to bump lib-utils to 1.0.0 in order to pick up new components required for hac-infra development.

@vojtechszocs FYI I tried updating lib-core as well, but there are a ton of TS errors using `1.0.0` around missing extension types. I pinged you offline. 

For now I'd like to merge this to unblock hac-infra and circle back on the core package.