### PR TITLE
Prepare for react-router v6 upgrade in chroming service

### DIFF
--- a/frontend/src/AppEntry.tsx
+++ b/frontend/src/AppEntry.tsx
@@ -3,9 +3,9 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { init, RegistryContext } from './store';
 import App from './App';
-import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import logger from 'redux-logger';
 import { InitializeSDK } from './sdk';
+import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 
 const AppEntry = () => {
   const registry = process.env.NODE_ENV !== 'production' ? init(logger) : init();
@@ -17,7 +17,7 @@ const AppEntry = () => {
     >
       <Provider store={registry.getStore()}>
         <InitializeSDK>
-          <Router basename={getBaseName(window.location.pathname, 1)}>
+          <Router basename={getBaseName(window.location.pathname, 0)}>
             <App />
           </Router>
         </InitializeSDK>

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -15,8 +15,8 @@ export const Routes: React.FC = () => (
     }
   >
     <DomRoutes>
-      <Route path="/*" element={<DynamicRoute />} />
-      <Route path="/testK8s" element={<TestK8s />} />
+      <Route path="/hac/testK8s" element={<TestK8s />} />
+      <Route path="/hac/*" element={<DynamicRoute />} />
     </DomRoutes>
   </React.Suspense>
 );


### PR DESCRIPTION
### Description

Since we want to upgrade to react-router-dom v6 in chroming service soon. We have to come up with a migrate plan. This PR wraps each navigation component and hook with specific config to prepend `/hac` prefix to all `to` arguments. Any hac plugin will have to update their navigation links in order to remove this hacky approach.