### PR TITLE
Listen to root routes as well

### DIFF
--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -16,7 +16,9 @@ export const Routes: React.FC = () => (
   >
     <DomRoutes>
       <Route path="/hac/testK8s" element={<TestK8s />} />
+      <Route path="/testK8s" element={<TestK8s />} />
       <Route path="/hac/*" element={<DynamicRoute />} />
+      <Route path="/*" element={<DynamicRoute />} />
     </DomRoutes>
   </React.Suspense>
 );

--- a/frontend/src/sdk/createStore.ts
+++ b/frontend/src/sdk/createStore.ts
@@ -4,7 +4,7 @@ import { PluginLoader, PluginLoaderOptions, PluginStore } from '@openshift/dynam
 import type { To, NavigateOptions } from 'react-router-dom';
 
 const calculateTo = (to: To) => {
-  if (typeof to === 'string' && !to.startsWith('/hac')) {
+  if (typeof to === 'string' && !to.startsWith('/hac') && to.startsWith('/')) {
     return `/hac${to}`;
   } else if (typeof to !== 'string' && to.pathname && !to.pathname.startsWith('/hac')) {
     return {
@@ -43,8 +43,7 @@ const modules: { [name: string]: () => Promise<() => any> } = {
       Link: (props: any) => {
         const react = require('react');
         const Cmp = reactRouter.Link;
-        const to = props.to.startsWith('/hac') ? props.to : `/hac${props.to}`;
-        return react.createElement(Cmp, { ...props, to });
+        return react.createElement(Cmp, { ...props, to: calculateTo(props.to) });
       },
       Navigate: (props: any) => {
         const react = require('react');


### PR DESCRIPTION
### Description

Navigation doesn't work on hac routes. There's a problem that current chrome doesn't have new basename and so it doesn't send nav changes to hac application with hac prefix.