### PR TITLE
Add option to use active workspace via custom extension

### DIFF
--- a/frontend/config/dev.webpack.config.js
+++ b/frontend/config/dev.webpack.config.js
@@ -64,6 +64,15 @@ const webpackProxy = {
   },
   customProxy: [
     {
+      context: (path) => path.includes('/api/kcp'),
+      target: 'https://api-toolchain-host-operator.apps.appstudio-stage.x99m.p1.openshiftapps.com:443',
+      secure: false,
+      changeOrigin: true,
+      autoRewrite: true,
+      ws: true,
+      pathRewrite: { '^/api/kcp': '' },
+    },
+    {
       context: (path) => path.includes('/api/k8s/registration'),
       target: 'https://registration-service-toolchain-host-operator.apps.appstudio-stage.x99m.p1.openshiftapps.com',
       secure: false,

--- a/frontend/src/AppEntry.tsx
+++ b/frontend/src/AppEntry.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { init, RegistryContext } from './store';
+import { WorkspaceProvider } from './Utils/WorkspaceProvider'
 import App from './App';
 import logger from 'redux-logger';
 import { InitializeSDK } from './sdk';
@@ -9,6 +10,8 @@ import { getBaseName } from '@redhat-cloud-services/frontend-components-utilitie
 
 const AppEntry = () => {
   const registry = process.env.NODE_ENV !== 'production' ? init(logger) : init();
+  const [activeWorkspace, setActiveWorkspace] = React.useState<string | null>(null);
+
   return (
     <RegistryContext.Provider
       value={{
@@ -16,11 +19,18 @@ const AppEntry = () => {
       }}
     >
       <Provider store={registry.getStore()}>
-        <InitializeSDK>
-          <Router basename={getBaseName(window.location.pathname, 0)}>
-            <App />
-          </Router>
-        </InitializeSDK>
+        <WorkspaceProvider.Provider value={{
+          setActiveWorkspace: (workspace: string) => {
+            setActiveWorkspace((activeWorkspace) => activeWorkspace !== workspace ? workspace : activeWorkspace);
+          },
+          activeWorkspace
+        }}>
+          <InitializeSDK>
+            <Router basename={getBaseName(window.location.pathname, 0)}>
+              <App />
+            </Router>
+          </InitializeSDK>
+        </WorkspaceProvider.Provider>
       </Provider>
     </RegistryContext.Provider>
   );

--- a/frontend/src/Utils/WorkspaceProvider.tsx
+++ b/frontend/src/Utils/WorkspaceProvider.tsx
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+
+export type SetActiveWorkspace = (workspace: string) => void;
+
+export type Workspace = {
+  setActiveWorkspace: SetActiveWorkspace;
+  activeWorkspace: string | null;
+};
+
+export const WorkspaceProvider = createContext<Workspace>({} as Workspace);

--- a/frontend/src/sdk/InitializeSDK.tsx
+++ b/frontend/src/sdk/InitializeSDK.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { AppInitSDK } from '@openshift/dynamic-plugin-sdk-utils';
 import Loader from '../Utils/Loader';
 import useAppConfiguration from './useAppConfiguration';
+import { WorkspaceProvider } from '../Utils/WorkspaceProvider';
 
 const InitializeSDK: React.FC = ({ children }) => {
   const appConfigurations = useAppConfiguration();
@@ -16,4 +17,9 @@ const InitializeSDK: React.FC = ({ children }) => {
   return <AppInitSDK configurations={appConfigurations}>{children as any}</AppInitSDK>;
 };
 
-export default InitializeSDK;
+const SDKWrapper: React.FC = ({ children }) => {
+  const { activeWorkspace } = React.useContext(WorkspaceProvider);
+  return <InitializeSDK key={activeWorkspace}>{children as any}</InitializeSDK>
+}
+
+export default SDKWrapper;

--- a/frontend/src/sdk/commonFetch.ts
+++ b/frontend/src/sdk/commonFetch.ts
@@ -1,6 +1,7 @@
 import { HttpError } from './httpError';
 
 const k8sBasePath = `/api/k8s`;
+const kcpBasePath = `/api/kcp/clusters/`;
 
 type AuthConfig = {
   getToken: () => Promise<String>;
@@ -47,8 +48,7 @@ export const validateStatus = async (response: Response) => {
 };
 
 export const commonFetch =
-  (auth: AuthConfig) =>
-  async (url: string, { pathPrefix, ...options }: RequestInit & { pathPrefix?: string } = {}): Promise<Response> => {
+  (auth: AuthConfig, activeWorkspace?: string | null) => async (url: string, { pathPrefix, ...options }: RequestInit & { pathPrefix?: string } = {}): Promise<Response> => {
     const token = await auth.getToken();
     if (!token) {
       return Promise.reject('Could not make k8s call. Unable to find token.');
@@ -62,8 +62,11 @@ export const commonFetch =
         Authorization: `Bearer ${token}`,
       },
     };
-
-    const prefix = `${(pathPrefix ?? k8sBasePath).indexOf('/') === 0 ? '' : '/'}${pathPrefix ?? k8sBasePath}`;
+    
+    let prefix = `${kcpBasePath}${activeWorkspace}`;
+    if (!activeWorkspace) {
+      prefix = `${(pathPrefix ?? k8sBasePath).indexOf('/') === 0 ? '' : '/'}${pathPrefix ?? k8sBasePath}`;
+    }
 
     try {
       let safeURL = url;

--- a/frontend/src/sdk/createStore.ts
+++ b/frontend/src/sdk/createStore.ts
@@ -2,6 +2,7 @@ import { getActivePlugins } from '../Utils/plugins';
 import packageInfo from '../../package.json';
 import { PluginLoader, PluginLoaderOptions, PluginStore } from '@openshift/dynamic-plugin-sdk';
 import type { To, NavigateOptions } from 'react-router-dom';
+import { WorkspaceProvider } from '../Utils/WorkspaceProvider';
 
 const calculateTo = (to: To) => {
   if (typeof to === 'string' && !to.startsWith('/hac')) {
@@ -91,6 +92,15 @@ export const createStore = () => {
       pluginStore.loadPlugin(url);
     });
   });
+  pluginStore.addPlugin({ name: 'hac-core', version: '0.0.1' }, [{
+    type: 'custom/active-workspace',
+    properties: {
+      getProvider: () => WorkspaceProvider
+    },
+    pluginName: 'hac-core',
+    uid: 'hac-core-active-workspace'
+  }]);
+  pluginStore.enablePlugins(['hac-core']);
   return pluginStore;
 };
 export const pluginStore = createStore();


### PR DESCRIPTION
### Example

Since we are using custom extension we have to also conume it in slightly different way. You can use either `flag` or custom context provider to wrap each route with activating current WS. The simplest way would be to use feature flag and have the page depend on that value to be present. Here is example of usage as flag and direct access to the provider value in specific route.

* **Ferature flag example**

You can define new `core.flag` and whenever page requires the WS to be set you can add the `ACTIVE_WS` in `required` field.

```TS
function isActiveWorkspaceProvider(extension: Extension): extension is Extension {
  return extension.type === 'custom/active-workspace';
}

type GetProvider = {
  getProvider: () => any;
};

type ActiveWSProvider = {
  activeWorkspace: string;
  setActiveWorkspace: (activeWs: string) => void;
};

export const useActiveWS = async (setFlag) => {
  const [[contextProviderExtensions]] = useResolvedExtensions(isActiveWorkspaceProvider);
  const { getProvider }: GetProvider = (contextProviderExtensions?.properties as GetProvider) || {
    getProvider: () => undefined,
  };
  const provider = getProvider();
  const wsProvider = React.useContext<ActiveWSProvider>(provider || React.createContext(null));
  if (wsProvider && !wsProvider.activeWorkspace) {
    // eslint-disable-next-line no-console
    console.log('Perform fetch and set activeWS', wsProvider);
  }
  setFlag('ACTIVE_WS', true);
};
```

* **Wrapper example**

More straight forward approach would be to wrap your routes with a wrapper, that consumes the provider and passes it down to your route.

```TSX

const TestCmp: React.FC<{ workspaceProvider: any }> = ({ workspaceProvider }) => {
  const { setActiveWorkspace, activeWorkspace } = React.useContext<{ setActiveWorkspace: (ws: string) => void, activeWorkspace: string }>(workspaceProvider);

  React.useEffect(() => {
    if (!activeWorkspace) {
      setActiveWorkspace('root');
    }
  }, []);

  return <div>foo</div>;
}

function isActiveWorkspaceProvider(extension: Extension): extension is Extension {
  return extension.type === 'custom/active-workspace';
}

type GetProvider = {
  getProvider: () => any;
};

type ActiveWSProvider = {
  activeWorkspace: string;
  setActiveWorkspace: (activeWs: string) => void;
};

const TestWrapper = () => {
  const [[contextProviderExtensions]] = useResolvedExtensions(isActiveWorkspaceProvider);
  const { getProvider }: GetProvider = (contextProviderExtensions?.properties as GetProvider) || {
      getProvider: () => undefined,
    };
  return getProvider ? <TestCmp workspaceProvider={getProvider()}/> : <div>loading</div>;
}

export default TestWrapper;
```

### Depends on
* [ ] https://github.com/openshift/dynamic-plugin-sdk/pull/183