### PR TITLE
Remove temporary websocket fixes

### DIFF
--- a/frontend/src/sdk/useAppConfiguration.ts
+++ b/frontend/src/sdk/useAppConfiguration.ts
@@ -8,18 +8,9 @@ import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome'
 
 type AppConfigurations = React.ComponentProps<typeof AppInitSDK>['configurations'];
 
-// TODO: remove once RHCLOUD-24173 is fixed and return just `wss://${location.host}${prefix || '/wss/k8s'}`
 const getWsURL = ({ wsPrefix, pathPrefix }: { wsPrefix?: string; pathPrefix?: string } = {}) => {
   const prefix = (wsPrefix || pathPrefix || '') as string;
-  if (localStorage.getItem('hac/proxy-ws') !== null) {
-    return `wss://${location.host}${prefix || '/wss/k8s'}`;
-  }
-
-  if (location.origin.includes('console.dev.redhat.com')) {
-    return `wss://api-toolchain-host-operator.apps.stone-stg-host1.hjvn.p1.openshiftapps.com${prefix}`;
-  }
-
-  return `wss://api-toolchain-host-operator.apps.appstudio-stage.x99m.p1.openshiftapps.com:443${prefix}`;
+  return `wss://${location.host}${prefix || '/wss/k8s'}`;
 };
 
 const useAppConfiguration = (): AppConfigurations | null => {


### PR DESCRIPTION
We discovered that Akamai was forwarding the `/wss/k8s` path prefix to the devsandbox proxy, and devsandbox was returning 403 due to the incorrect path.

Akamai is currently being updated and we should be able to test/merge this PR.