### PR TITLE
Bump SDK to v3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "verify": "yarn build && yarn lint && yarn test"
   },
   "dependencies": {
-    "@openshift/dynamic-plugin-sdk": "^2.0.1",
+    "@openshift/dynamic-plugin-sdk": "^3.0.0",
     "@openshift/dynamic-plugin-sdk-extensions": "^1.1.0",
     "@openshift/dynamic-plugin-sdk-utils": "^1.1.1",
     "@patternfly/patternfly": "^4.185.1",
@@ -66,8 +66,8 @@
     "@patternfly/react-virtualized-extension": "^4.53.2",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.3",
     "@redhat-cloud-services/frontend-components-config": "^4.6.14",
-    "@scalprum/core": "0.4.0",
-    "@scalprum/react-core": "0.4.0-beta.6",
+    "@scalprum/core": "0.5.1",
+    "@scalprum/react-core": "0.5.1",
     "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "12.1.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -616,10 +616,10 @@
     typesafe-actions "^4.4.2"
     uuid "^8.3.2"
 
-"@openshift/dynamic-plugin-sdk@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-2.0.1.tgz#5bf81b224171c982c32f6cfa2bd8034077b18327"
-  integrity sha512-fiSPxk8ghs/aEp7UasDBhjdXrQ5/IQl+QuCB8FHz6IhAkN5mB/aQ7GcBHfW+ITK4g0eb6ydb4x2IaKP8iZeBJw==
+"@openshift/dynamic-plugin-sdk@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-3.0.0.tgz#9b7f06ef868584e05e145c02a0794bf9c93b5745"
+  integrity sha512-HHVjKxlssDS92DwfPGmeDbnZN+zR96juDTBEJEUluWwvyIqwgopx9GD5YrDGPDv8XvrG5TajJ/yJ9j2Wt4ap4g==
   dependencies:
     lodash-es "^4.17.21"
     semver "^7.3.7"
@@ -823,32 +823,25 @@
   resolved "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.1.tgz"
   integrity sha512-UgHgLf8LkqaD9PXjiVyYycMRlbvmVdJyoJfersCUwnzDMgp+DEoYlLQAa9kn/s4c1JvSt5MM+hEN+DRvwtCQGA==
 
-"@scalprum/core@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@scalprum/core/-/core-0.4.0.tgz#074db53ae2bb91e327d47cd5d4504c3ea1079b95"
-  integrity sha512-MZ1tyCQdFV60X7i0cb85oAFpJluWgyrKlekaJO2uGLLKgyWbY0eNq/m3kTwIasEsTLPEFsDbmaPCCKvsIV9abw==
+"@scalprum/core@0.5.1", "@scalprum/core@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@scalprum/core/-/core-0.5.1.tgz#c5cf6fa980c834ab2d8461916d5145e72ac78265"
+  integrity sha512-xYj9GRXleYMo2bsbdHN9fJmmwPkUHI9sjEoJU7jWoKzfTZTQWnhHVGjW53XOhtz4NO4lAZGPID7dbuJksNyvuA==
   dependencies:
-    "@openshift/dynamic-plugin-sdk" "^2.0.1"
-
-"@scalprum/core@0.4.0-beta.6":
-  version "0.4.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@scalprum/core/-/core-0.4.0-beta.6.tgz#318df0a14b72be11834385915e50040f97ae3fe8"
-  integrity sha512-wPKUm8fVdd7OIkDKZfx7fdAeCtTqN9HQXCemrvVHQKQUPG/szwtq+t8Wo+chytfZJ0aPgaMfu/2TtPRdWQDdRg==
-  dependencies:
-    "@openshift/dynamic-plugin-sdk" "^2.0.1"
+    "@openshift/dynamic-plugin-sdk" "^3.0.0"
 
 "@scalprum/core@^0.1.1", "@scalprum/core@^0.1.2":
   version "0.1.2"
   resolved "https://registry.npmjs.org/@scalprum/core/-/core-0.1.2.tgz"
   integrity sha512-dupFyb1niBpyy1Mb6+bSbhZhNGYGQ4T32iNNdLB6Pvey64bApSnXl7AFl2D8468xO1YTb4Bah1libovLWvZovQ==
 
-"@scalprum/react-core@0.4.0-beta.6":
-  version "0.4.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@scalprum/react-core/-/react-core-0.4.0-beta.6.tgz#5fa617bdbca2167afd0684fb3e96eb9d383998a0"
-  integrity sha512-wtu43yWWXBbm7fFmSY0a9KPXjAxLe5z16e7FOBOCGZIS0x3/llWFRi5KWXcQKkqhIdry3hpAHVtBu3xXqBXCnw==
+"@scalprum/react-core@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@scalprum/react-core/-/react-core-0.5.1.tgz#eed3ce75e38f16a091e993b36e18a53c783ec769"
+  integrity sha512-S3R/cSA9Dlrf4REwDIH80d5M+lEzzYhYHCPOFzmt1Zm3v4sFkFAUx9ZARfyrWK0UOYfXUE/L6D6R1lGgTWm54Q==
   dependencies:
-    "@openshift/dynamic-plugin-sdk" "^2.0.1"
-    "@scalprum/core" "0.4.0-beta.6"
+    "@openshift/dynamic-plugin-sdk" "^3.0.0"
+    "@scalprum/core" "^0.5.1"
     lodash "^4.17.0"
 
 "@scalprum/react-core@^0.1.7":


### PR DESCRIPTION
Should be merged with: https://github.com/RedHatInsights/insights-chrome/pull/2337

The hac-core will work eve if chrome PR was merged before. But we should keep this critical dependency in sync.

We plan to do the merge and deploy on Monday
