### PR TITLE
Add SDK v4 compatibility layer.

### DIFF
--- a/frontend/src/sdk/createStore.ts
+++ b/frontend/src/sdk/createStore.ts
@@ -16,9 +16,17 @@ export const createStore = (store?: PluginStore) => {
     internalStore = new PluginStore();
     internalStore.setLoader(loader);
   }
+  let storeMajorVersion: number;
+  try {
+    // @ts-ignore
+    storeMajorVersion = Number(internalStore?.sdkVersion?.split('.')?.[0] ?? '3');
+  } catch {
+    // fallback to pre v4 version
+    storeMajorVersion = 3;
+  }
   getActivePlugins(window.insights.chrome.isBeta(), packageInfo.insights.appname).then((data) => {
     data.forEach(({ name: item, pathPrefix = '/api/plugins' }) => {
-      const url = `/beta${pathPrefix}/${item}/`;
+      const url = storeMajorVersion < 4 ? `/beta${pathPrefix}/${item}/` : `/beta${pathPrefix}/${item}/plugin-manifest.json`;
       internalStore!.loadPlugin(url);
     });
   });


### PR DESCRIPTION
This is change is required to enable a bridge between SDK 3 and 4 for hac apps.

requires: https://github.com/RedHatInsights/insights-chrome/pull/2663
 
cc @karelhala 